### PR TITLE
Bump version to 0.18.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(path.dirname(__file__), 'requirements.txt')) as requirements
 
 setuptools.setup(
     name='django-declarative-apis',
-    version='0.18.3',
+    version='0.18.4',
     author='Drew Shafer',
     url='https://salesforce.com',
     description='Simple, readable, declarative APIs for Django',


### PR DESCRIPTION
Required because PyPI disallows re-use of the same filename