### PR TITLE
Bringing bumpversion config and docs version up to date

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.18.2
+current_version = 0.18.4
 
 [bumpversion:file:setup.py]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,7 @@ author = 'Salesforce'
 # built documents.
 
 # The full version, including alpha/beta/rc tags.
-release = '0.18.2'
+release = '0.18.4'
 
 # The short X.Y version.
 version = release.rsplit('.', 1)[0]


### PR DESCRIPTION
Missed during public release