### PR TITLE
Fix to allow for most recent celery version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-celery>=4.0.2,<=4.2.1,!=4.1.0
+celery>=4.0.2,<=4.3.0,!=4.1.0
 cryptography>=2.0,<=2.6
 decorator==4.0.11
 django-dirtyfields>=1.2.1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(path.dirname(__file__), 'requirements.txt')) as requirements
 
 setuptools.setup(
     name='django-declarative-apis',
-    version='0.18.4',
+    version='0.18.5',
     author='Drew Shafer',
     url='https://salesforce.com',
     description='Simple, readable, declarative APIs for Django',


### PR DESCRIPTION
Doesn't break backwards compatibility with previous versions of celery. Seems that types were previously serialized, but that's no longer the case.