### PR TITLE
Update pyyaml dev requirement to fix GitHub security warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+# []
+### Fixed
+- [PR 18](https://github.com/salesforce/django-declarative-apis/pull/18) Bump PyYaml dev requirement version
+
 # [0.19.3] - 2020-02-04
 - Increase celery version range
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ ipython==4.2.1
 mock==2.0.0
 oauth2==1.9.0.post1
 tox==2.6.0
-pyyaml==3.13
+pyyaml~=5.3
 sphinx_rtd_theme==0.4.2
 bumpversion~=0.5
 flake8~=3.7.0


### PR DESCRIPTION
Resolves GitHub security warning.

>Remediation
>Upgrade pyyaml to version 4.2b1 or later. For example:

> pyyaml>=4.2b1

This is a dev dependency, so I don't see why we shouldn't upgrade to the latest.