### PR TITLE
Bump Django patch version to fix GitHub security warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+# []
+### Fixed
+- [PR 19](https://github.com/salesforce/django-declarative-apis/pull/19) Bump required Django patch version
+
 # [0.19.3] - 2020-02-04
 - Increase celery version range
 

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,3 +1,3 @@
-Django>=1.10.6,<=1.11.20
-django-sslserver==0.20
 ../../django-declarative-apis
+Django~=1.11.28
+django-sslserver==0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ celery>=4.0.2,<=4.4.0,!=4.1.0
 cryptography>=2.0,<=2.6
 decorator==4.0.11
 django-dirtyfields>=1.2.1
-Django~=1.11.0
+Django~=1.11.28
 oauthlib[signedtoken,rsa]>=2.0.6,<3.1.0


### PR DESCRIPTION
Updating to Django 2.2 will come next, but we might as well fix this warning since it's easy.