### PR TITLE
Add Makefile targets for Black code formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
 # []
+### Added
+- [PR 21](https://github.com/salesforce/django-declarative-apis/pull/21) Add Makefile targets for Black formatter
+
 ### Fixed
 - [PR 19](https://github.com/salesforce/django-declarative-apis/pull/19) Bump required Django patch version
 - [PR 20](https://github.com/salesforce/django-declarative-apis/pull/20) Fix deprecation warnings

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,16 @@
 PYTHON=python
 PACKAGE_DIR = django_declarative_apis
 TEST_DIR = tests
+EXAMPLE_DIR = example
+
 TEST_CMD = ${PYTHON} manage.py test --parallel
 TEST_WARNINGS_CMD = ${PYTHON} -Wa manage.py test
 # see .coveragerc for settings
 COVERAGE_CMD = coverage run manage.py test --noinput && coverage xml && coverage report
-STATIC_CMD = flake8 ${PACKAGE_DIR}
+STATIC_CMD = flake8 ${PACKAGE_DIR} ${TEST_DIR} ${EXAMPLE_DIR} setup.py
 VULN_STATIC_CMD = bandit -r -ii -ll -x ${PACKAGE_DIR}/migrations ${PACKAGE_DIR} 
-FORMATCHECK_CMD = black --check ${PACKAGE_DIR} ${TEST_DIR}
+FORMAT_CMD = black ${PACKAGE_DIR} ${TEST_DIR} ${EXAMPLE_DIR} setup.py
+FORMATCHECK_CMD = ${FORMAT_CMD} --check
 
 
 install:
@@ -16,7 +19,7 @@ install:
 .PHONY: install
 
 format:
-	black ${PACKAGE_DIR} ${TEST_DIR}
+	${FORMAT_CMD}
 .PHONY: format
 
 docs:

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ readme:
 
 # Test targets
 
-test-all: coverage static vuln-static
+test-all: coverage static vuln-static formatcheck
 .PHONY: test-all
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,35 @@
 # Common variables
 PYTHON=python
 PACKAGE_DIR = django_declarative_apis
-TEST_CMD = ${PYTHON} ./manage.py test --parallel
+TEST_DIR = tests
+TEST_CMD = ${PYTHON} manage.py test --parallel
 TEST_WARNINGS_CMD = ${PYTHON} -Wa manage.py test
 # see .coveragerc for settings
 COVERAGE_CMD = coverage run manage.py test --noinput && coverage xml && coverage report
 STATIC_CMD = flake8 ${PACKAGE_DIR}
 VULN_STATIC_CMD = bandit -r -ii -ll -x ${PACKAGE_DIR}/migrations ${PACKAGE_DIR} 
+FORMATCHECK_CMD = black --check ${PACKAGE_DIR} ${TEST_DIR}
 
-# Local (non-Docker) targets
 
 install:
 	pip install -r requirements.txt -r requirements-dev.txt
 .PHONY: install
+
+format:
+	black ${PACKAGE_DIR} ${TEST_DIR}
+.PHONY: format
+
+docs:
+	pushd docs && DJANGO_SETTINGS_MODULE=tests.settings make html && popd
+.PHONY: docs
+
+readme:
+	@pandoc -f rst -t markdown_github docs/source/overview.rst > README.md
+	@echo "\n\n" >> README.md
+	@pandoc -f rst -t markdown_github docs/source/quickstart.rst >> README.md
+.PHONY: readme
+
+# Test targets
 
 test-all: coverage static vuln-static
 .PHONY: test-all
@@ -37,12 +54,6 @@ vuln-static:
 	${VULN_STATIC_CMD}
 .PHONY: vuln-static
 
-docs:
-	pushd docs && DJANGO_SETTINGS_MODULE=tests.settings make html && popd
-.PHONY: docs
-
-readme:
-	@pandoc -f rst -t markdown_github docs/source/overview.rst > README.md
-	@echo "\n\n" >> README.md
-	@pandoc -f rst -t markdown_github docs/source/quickstart.rst >> README.md
-.PHONY: readme
+formatcheck:
+	${FORMATCHECK_CMD}
+.PHONY: formatcheck

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,4 +9,3 @@ oauth2==1.9.0.post1
 pyyaml~=5.3
 sphinx_rtd_theme==0.4.2
 tox==2.6.0
-tox==2.6.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ sphinx_rtd_theme==0.4.2
 bumpversion~=0.5
 flake8~=3.7.0
 bandit~=1.6
+black==19.3b0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
+bandit~=1.6
+black==19.3b0
+bumpversion~=0.5
 coverage==4.3.4
+flake8~=3.7.0
 ipython==4.2.1
 mock==2.0.0
 oauth2==1.9.0.post1
-tox==2.6.0
 pyyaml==3.13
 sphinx_rtd_theme==0.4.2
-bumpversion~=0.5
-flake8~=3.7.0
-bandit~=1.6
-black==19.3b0
+tox==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
+Django~=1.11.28
 celery>=4.0.2,<=4.4.0,!=4.1.0
 cryptography>=2.0,<=2.6
 decorator==4.0.11
 django-dirtyfields>=1.2.1
-Django~=1.11.28
 oauthlib[signedtoken,rsa]>=2.0.6,<3.1.0


### PR DESCRIPTION
* Add Make targets for Black formatting, but don't actually format the codebase yet.
* Add Black as a dev dependency
* Sort requirements.txt and requirements-dev.txt, but don't change any dependencies (other than Black)
