### PR TITLE
Fix uncontroversial flake8 warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - [PR 19](https://github.com/salesforce/django-declarative-apis/pull/19) Bump required Django patch version
 - [PR 20](https://github.com/salesforce/django-declarative-apis/pull/20) Fix deprecation warnings
 - [PR 20](https://github.com/salesforce/django-declarative-apis/pull/20) Fix incorrect version number in docs and .bumpversion
+- [PR 23](https://github.com/salesforce/django-declarative-apis/pull/23) Fix some flake8 warnings
 
 # [0.19.3] - 2020-02-04
 - Increase celery version range

--- a/django_declarative_apis/authentication/__init__.py
+++ b/django_declarative_apis/authentication/__init__.py
@@ -12,7 +12,7 @@ import typing
 class AuthenticatorHint(typing.NamedTuple):
     """ Tuple to provide hints for authentication implementations
 
-    header_hint: A string used to match the `Authentication: ` header. 
+    header_hint: A string used to match the `Authentication: ` header.
     """
 
     header: str

--- a/django_declarative_apis/authentication/oauthlib/oauth1.py
+++ b/django_declarative_apis/authentication/oauthlib/oauth1.py
@@ -83,7 +83,7 @@ class TwoLeggedOauth1(Authenticator):
 
         headers = {k: v for (k, v) in request.META.items() if isinstance(v, str)}
 
-        if body_form_data and not "Content-Type" in headers:  # pragma: nocover
+        if body_form_data and "Content-Type" not in headers:  # pragma: nocover
             # TODO: is this only necessary because our test client sucks?
             # TODO (DB): is this still needed?
             headers["Content-Type"] = "application/x-www-form-urlencoded"

--- a/django_declarative_apis/authentication/oauthlib/oauth1.py
+++ b/django_declarative_apis/authentication/oauthlib/oauth1.py
@@ -57,7 +57,7 @@ class TwoLeggedOauth1(Authenticator):
             missing = list(
                 param for param in params if param not in collected_request_parameters
             )
-        except:  # pragma: nocover
+        except Exception:  # pragma: nocover
             missing = params
 
         if missing:

--- a/django_declarative_apis/machinery/__init__.py
+++ b/django_declarative_apis/machinery/__init__.py
@@ -521,7 +521,7 @@ class EndpointDefinition(BaseEndpointDefinition):
             ``bool``: Whether or not the user has permission to the resource.
         """
         if (
-            self._consumer_type == None
+            self._consumer_type is None
             or self._consumer_type == BaseConsumer.TYPE_READ_WRITE
         ):
             return True

--- a/django_declarative_apis/resources/emitters.py
+++ b/django_declarative_apis/resources/emitters.py
@@ -5,7 +5,9 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 
-import decimal, re, inspect
+import decimal
+import re
+import inspect
 import copy
 
 from django.conf import settings

--- a/django_declarative_apis/resources/resource.py
+++ b/django_declarative_apis/resources/resource.py
@@ -239,7 +239,7 @@ class Resource(object):
                 else:
                     request.data = request.PUT
 
-        if not rm in handler.allowed_methods:
+        if rm not in handler.allowed_methods:
             return HttpResponseNotAllowed(handler.allowed_methods)
 
         meth = handler.method_handlers.get(rm, None)

--- a/django_declarative_apis/resources/utils.py
+++ b/django_declarative_apis/resources/utils.py
@@ -107,7 +107,7 @@ class rc_factory(object):
 
             try:
                 content = property(HttpResponse._get_content, _set_content)
-            except:
+            except Exception:
 
                 @HttpResponse.content.setter
                 def content(self, content):

--- a/example/myapp/resources.py
+++ b/example/myapp/resources.py
@@ -74,7 +74,7 @@ class PingDefinition(machinery.BaseEndpointDefinition):
     def resource(self):
         """The endpoint resource
 
-        Endpoint resources can be implemented as either properties or machinery.endpoint_resources. 
+        Endpoint resources can be implemented as either properties or machinery.endpoint_resources.
         The latter will require filters to be defined.
         """
         return {"ping": "pong"}


### PR DESCRIPTION
Hopefully this set of flake8 fixes is uncontroversial.

There are a few more "unused local variable" warnings that I'll have to look at more closely.

Next, I'll tackle a raft of "unused import" errors.  I saw test errors when doing the obvious thing and just removing all the unused imports, so I'll have to try again more carefully.