### PR TITLE
Fix deprecation warnings and versions

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.18.5
+current_version = 0.19.3
 
 [bumpversion:file:setup.py]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - [PR 18](https://github.com/salesforce/django-declarative-apis/pull/18) Bump PyYaml dev requirement version
 - [PR 19](https://github.com/salesforce/django-declarative-apis/pull/19) Bump required Django patch version
+- [PR 20](https://github.com/salesforce/django-declarative-apis/pull/20) Fix deprecation warnings
+- [PR 20](https://github.com/salesforce/django-declarative-apis/pull/20) Fix incorrect version number in docs and .bumpversion
 
 # [0.19.3] - 2020-02-04
 - Increase celery version range

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 PYTHON=python
 PACKAGE_DIR = django_declarative_apis
 TEST_CMD = ${PYTHON} ./manage.py test --parallel
+TEST_WARNINGS_CMD = ${PYTHON} -Wa manage.py test
 # see .coveragerc for settings
 COVERAGE_CMD = coverage run manage.py test --noinput && coverage xml && coverage report
 STATIC_CMD = flake8 ${PACKAGE_DIR}
@@ -19,6 +20,10 @@ test-all: coverage static vuln-static
 test:
 	${TEST_CMD}
 .PHONY: test
+
+test-warnings:
+	${TEST_WARNINGS_CMD}
+.PHONY: test-warnings
 
 coverage:
 	${COVERAGE_CMD}

--- a/django_declarative_apis/machinery/attributes.py
+++ b/django_declarative_apis/machinery/attributes.py
@@ -6,7 +6,7 @@
 #
 
 import abc
-import collections
+import collections.abc
 import logging
 import random
 import string
@@ -112,7 +112,7 @@ class TypedEndpointAttributeMixin(object):
             if self.field_type == bool and not isinstance(raw_value, self.field_type):
                 return 'rue' in raw_value
             else:
-                if isinstance(raw_value, collections.Iterable) and not isinstance(raw_value, (str, dict)):
+                if isinstance(raw_value, collections.abc.Iterable) and not isinstance(raw_value, (str, dict)):
                     return list(self.field_type(r) for r in raw_value)
                 else:
                     return self.field_type(raw_value)

--- a/django_declarative_apis/machinery/tasks.py
+++ b/django_declarative_apis/machinery/tasks.py
@@ -95,7 +95,7 @@ def _log_retry_stats(method_name, resource_instance_id, correlation_id):
         newrelic_agent.record_custom_event('task_runner:retry',
                                            {'method_name': method_name,
                                             'resource_instance_id': resource_instance_id})
-        logger.warn(
+        logger.warning(
             'will retry task: method=%s, resource_id=%s, correlation_id=%s', method_name, resource_instance_id,
             correlation_id
         )
@@ -200,10 +200,10 @@ def schedule_future_task_runner(task_runner_args, task_runner_kwargs,
                 future_task_runner.apply_async(task_runner_args, task_runner_kwargs, queue=queue, routing_key=routing_key, countdown=countdown+delay)
                 return
             except kombu.exceptions.OperationalError as err:
-                logger.warn('kombu.exceptions.OperationalError (attempt: %s)', attempt)
+                logger.warning('kombu.exceptions.OperationalError (attempt: %s)', attempt)
                 if attempt >= MAX_ATTEMPTS - 1:
                     if getattr(settings, 'DECLARATIVE_ENDPOINT_TASKS_SYNCHRONOUS_FALLBACK'):
-                        logger.warn('Falling back to executing task synchronously')
+                        logger.warning('Falling back to executing task synchronously')
                         future_task_runner.apply(task_runner_args, task_runner_kwargs)
                         return
                     raise err

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,7 @@ author = 'Salesforce'
 # built documents.
 
 # The full version, including alpha/beta/rc tags.
-release = '0.18.5'
+release = '0.19.3'
 
 # The short X.Y version.
 version = release.rsplit('.', 1)[0]


### PR DESCRIPTION
* Add a make target for testing with deprecation warnings turned on
* Fix the deprecation warnings found (mostly logger.warn -> logger.warning)
* Fix a couple of missed version numbers.