### PR TITLE
flake8 - remove "local variable unused" warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - [PR 20](https://github.com/salesforce/django-declarative-apis/pull/20) Fix deprecation warnings
 - [PR 20](https://github.com/salesforce/django-declarative-apis/pull/20) Fix incorrect version number in docs and .bumpversion
 - [PR 23](https://github.com/salesforce/django-declarative-apis/pull/23) Fix some flake8 warnings
+- [PR 24](https://github.com/salesforce/django-declarative-apis/pull/24) Fix more flake8 warnings
 - [PR 26](https://github.com/salesforce/django-declarative-apis/pull/26) Use yaml.safe_load in test
 
 # [0.19.3] - 2020-02-04

--- a/django_declarative_apis/adapters.py
+++ b/django_declarative_apis/adapters.py
@@ -17,7 +17,7 @@ import django_declarative_apis.authentication
 # don't require resources unless this adapter is in use
 try:
     from django_declarative_apis.resources.resource import Resource
-except ImportError as e:  # pragma: nocover
+except ImportError:  # pragma: nocover
     import traceback
 
     traceback.print_exc()

--- a/django_declarative_apis/authentication/oauthlib/endpoint.py
+++ b/django_declarative_apis/authentication/oauthlib/endpoint.py
@@ -48,7 +48,7 @@ class TweakedSignatureOnlyEndpoint(SignatureOnlyEndpoint):
         """
         try:
             request = self._create_request(uri, http_method, body, headers)
-        except errors.OAuth1Error as e:
+        except errors.OAuth1Error:
             return False, None
 
         try:

--- a/django_declarative_apis/authentication/oauthlib/request_validator.py
+++ b/django_declarative_apis/authentication/oauthlib/request_validator.py
@@ -69,7 +69,7 @@ class DjangoRequestValidator(RequestValidator):
                 return None
             else:
                 return self.consumer.secret
-        except Exception as e:
+        except Exception:
             logging.error(
                 "This should never happen, since consumer is already validated"
             )
@@ -78,7 +78,7 @@ class DjangoRequestValidator(RequestValidator):
     def get_rsa_key(self, client_key, request):
         try:
             return self.consumer.rsa_public_key_pem
-        except Exception as e:
+        except Exception:
             logging.error(
                 "This should never happen, since consumer is already validated"
             )

--- a/django_declarative_apis/machinery/__init__.py
+++ b/django_declarative_apis/machinery/__init__.py
@@ -223,13 +223,13 @@ class EndpointBinder(object):
 
         try:
             self._bind_endpoint(endpoint)
-        except Exception as e:
+        except Exception:
             bound_endpoint_manager.binding_exc_info = sys.exc_info()
             return bound_endpoint_manager
 
         try:
             self._validate_endpoint(endpoint)
-        except Exception as e:
+        except Exception:
             bound_endpoint_manager.validation_exc_info = sys.exc_info()
 
         return bound_endpoint_manager
@@ -251,7 +251,7 @@ class EndpointBinder(object):
                         missing_required_properties.append(request_property)
             except errors.ClientErrorMissingFields as mfe:  # TODO: seems unreachable
                 extra_error_message += mfe.error_message  # pragma: nocover
-            except (ValueError, errors.ClientErrorInvalidFieldValues) as ve:
+            except (ValueError, errors.ClientErrorInvalidFieldValues):
                 # Collect invalid values and report them all together
                 invalid_value_properties.append(request_property)  # pragma: nocover
 

--- a/django_declarative_apis/machinery/attributes.py
+++ b/django_declarative_apis/machinery/attributes.py
@@ -130,7 +130,7 @@ class TypedEndpointAttributeMixin(object):
                     return list(self.field_type(r) for r in raw_value)
                 else:
                     return self.field_type(raw_value)
-        except Exception as e:
+        except Exception:
             raise errors.ClientErrorInvalidFieldValues(
                 [self.name],
                 "Could not parse {val} as type {type}".format(

--- a/django_declarative_apis/machinery/filtering.py
+++ b/django_declarative_apis/machinery/filtering.py
@@ -32,7 +32,7 @@ def expandable(model_class=None, display_key=None):
     if model_class and display_key:
         try:
             model_class._meta.get_field(display_key)
-        except models.FieldDoesNotExist as e:
+        except models.FieldDoesNotExist:
             raise ValueError(f"{display_key} is not a field on {model_class.__name__}")
     return _ExpandableForeignKey(display_key, model_class)
 
@@ -72,7 +72,7 @@ def _get_filtered_field_value(
     else:
         try:
             val = getattr(inst, field_name)
-        except (AttributeError, models.fields.FieldDoesNotExist) as e:
+        except (AttributeError, models.fields.FieldDoesNotExist):
             return None
 
     if isinstance(val, models.Manager):

--- a/django_declarative_apis/models.py
+++ b/django_declarative_apis/models.py
@@ -25,7 +25,7 @@ def get_consumer(key):
     if getter_str is None:
         try:
             return OauthConsumer.objects.get(key=key)
-        except OauthConsumer.DoesNotExist as e:
+        except OauthConsumer.DoesNotExist:
             return None
     else:
         module, getter = getter_str.rsplit(".", 1)

--- a/tests/machinery/test_base.py
+++ b/tests/machinery/test_base.py
@@ -207,7 +207,7 @@ class EndpointBinderTestCase(django.test.TestCase):
                 try:
                     manager.get_response()
                     self.fail("This should have failed")
-                except errors.ClientError as err:
+                except errors.ClientError:
                     # save should be called twice if the exception says the resource should be saved: once before
                     # tasks are executed and once during exception handling.
                     self.assertEqual(
@@ -830,7 +830,7 @@ class DeferrableTaskTestCase(django.test.TestCase):
 
             with self.settings(DECLARATIVE_ENDPOINT_TASKS_SYNCHRONOUS_FALLBACK=True):
                 try:
-                    resp = manager.get_response()
+                    manager.get_response()
                 except kombu.exceptions.OperationalError:
                     self.fail("OperationalError should not have been triggered")
                 finally:
@@ -858,7 +858,7 @@ class DeferrableTaskTestCase(django.test.TestCase):
 
             with self.settings(DECLARATIVE_ENDPOINT_TASKS_FORCE_SYNCHRONOUS=True):
                 try:
-                    resp = manager.get_response()
+                    manager.get_response()
                 except kombu.exceptions.OperationalError:
                     self.fail("OperationalError should not have been triggered")
                 finally:
@@ -900,7 +900,7 @@ class DeferrableTaskTestCase(django.test.TestCase):
             mock_apply.side_effect = _side_effect
 
             try:
-                resp = manager.get_response()
+                manager.get_response()
                 self.fail("should have triggered a kombu.exceptions.OperationalError")
             except kombu.exceptions.OperationalError:
                 pass

--- a/tests/resources/test_resource.py
+++ b/tests/resources/test_resource.py
@@ -52,7 +52,7 @@ class ResourceTestCase(testutils.RequestCreatorMixin, django.test.TestCase):
         ) as mock_translate:
             mock_translate.side_effect = resource.MimerDataException
 
-            resp = res(req)
+            res(req)
 
     def test_call_put(self):
         class Handler:
@@ -64,7 +64,7 @@ class ResourceTestCase(testutils.RequestCreatorMixin, django.test.TestCase):
         body = {"foo": "bar"}
         req = self.create_request(method="PUT", body=body)
         res = resource.Resource(lambda: Handler())
-        resp = res(req)
+        res(req)
 
         # make sure request coercion did its thing to allow django to support it
         self.assertEqual(req.PUT, req.POST)
@@ -139,7 +139,7 @@ class ResourceTestCase(testutils.RequestCreatorMixin, django.test.TestCase):
             with mock.patch(
                 "django_declarative_apis.resources.resource.Resource.email_exception"
             ) as mock_email:
-                resp = res.error_handler(err, req, "GET", "json")
+                res.error_handler(err, req, "GET", "json")
 
         (reporter,), kwargs = mock_email.call_args_list[0]
         self.assertEqual(mock_email.call_count, 1)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -22,7 +22,7 @@ class DeclarativeApisTestCase(TestCase):
         self.consumer = auth_models.OauthConsumer.objects.create()
 
     def test_simplest_endpoint(self):
-        response = self.client.get(
+        self.client.get(
             "/simple", consumer=self.consumer, expected_status_code=HTTPStatus.OK
         )
 


### PR DESCRIPTION
Clear some "local variable unused" warnings.

Note: I cut this PR down to just the "local variable unused" changes because there's some disagreement about this.  I've moved all the less controversial changes into #27 