### PR TITLE
Use yaml's `safe_load`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - [PR 19](https://github.com/salesforce/django-declarative-apis/pull/19) Bump required Django patch version
 - [PR 20](https://github.com/salesforce/django-declarative-apis/pull/20) Fix deprecation warnings
 - [PR 20](https://github.com/salesforce/django-declarative-apis/pull/20) Fix incorrect version number in docs and .bumpversion
+- [PR 26](https://github.com/salesforce/django-declarative-apis/pull/26) Use yaml.safe_load in test
 
 # [0.19.3] - 2020-02-04
 - Increase celery version range

--- a/tests/resources/test_emitters.py
+++ b/tests/resources/test_emitters.py
@@ -153,7 +153,7 @@ class YAMLEmitterTestCase(unittest.TestCase):
     def test_render(self):
         data = {"foo": "bar"}
         em = emitters.YAMLEmitter(data, lambda: None)
-        self.assertEqual(yaml.load(em.render(None)), data)
+        self.assertEqual(yaml.safe_load(em.render(None)), data)
 
 
 class PickleEmitterTestCase(unittest.TestCase):


### PR DESCRIPTION
Use yaml's `safe_load` to avoid deprecation warning:
```
/Users/robert.grant/projects/django-declarative-apis/tests/resources/test_emitters
.py:156: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  self.assertEqual(yaml.load(em.render(None)), data)
```