### PR TITLE
flake8 - primarily fix up imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - [PR 20](https://github.com/salesforce/django-declarative-apis/pull/20) Fix deprecation warnings
 - [PR 20](https://github.com/salesforce/django-declarative-apis/pull/20) Fix incorrect version number in docs and .bumpversion
 - [PR 23](https://github.com/salesforce/django-declarative-apis/pull/23) Fix some flake8 warnings
+- [PR 27](https://github.com/salesforce/django-declarative-apis/pull/27) Fix more flake8 warnings
 
 # [0.19.3] - 2020-02-04
 - Increase celery version range

--- a/django_declarative_apis/authentication/oauthlib/endpoint.py
+++ b/django_declarative_apis/authentication/oauthlib/endpoint.py
@@ -5,17 +5,11 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 
-import base64
 import logging
+
+from oauthlib.oauth1 import SignatureOnlyEndpoint
 from oauthlib.oauth1.rfc5849 import SIGNATURE_RSA
 from oauthlib.oauth1.rfc5849 import errors, signature
-from oauthlib.oauth1 import SignatureOnlyEndpoint
-from cryptography.hazmat.primitives.serialization import (
-    load_der_public_key,
-    PublicFormat,
-    Encoding,
-)
-from cryptography.hazmat.backends import default_backend
 
 from django_declarative_apis.resources.utils import preprocess_rsa_key
 

--- a/django_declarative_apis/authentication/oauthlib/oauth_errors.py
+++ b/django_declarative_apis/authentication/oauthlib/oauth_errors.py
@@ -21,10 +21,10 @@ class OAuthTimestampError(OAuthError):
             "There was a problem with your timestamp. Please check your current system time."
             "Server time is {0}.".format(time.time())
         )
-        header_fmt = 'OAuth realm="API",oauth_problem=timestamp_refused&oauth_acceptable_timestamps={0}-{1}'
-        self.auth_header = header_fmt.format(
-            int(time.time()) - 300, int(time.time())
-        )
+        start_time = int(time.time()) - 300
+        end_time = int(time.time())
+        self.auth_header = ('OAuth realm="API",oauth_problem=timestamp_refused'
+                            f'&oauth_acceptable_timestamps={start_time}-{end_time}')
 
 
 class OAuthMissingParameterError(OAuthError):

--- a/django_declarative_apis/authentication/oauthlib/oauth_errors.py
+++ b/django_declarative_apis/authentication/oauthlib/oauth_errors.py
@@ -21,7 +21,8 @@ class OAuthTimestampError(OAuthError):
             "There was a problem with your timestamp. Please check your current system time."
             "Server time is {0}.".format(time.time())
         )
-        self.auth_header = 'OAuth realm="API",oauth_problem=timestamp_refused&oauth_acceptable_timestamps={0}-{1}'.format(
+        header_fmt = 'OAuth realm="API",oauth_problem=timestamp_refused&oauth_acceptable_timestamps={0}-{1}'
+        self.auth_header = header_fmt.format(
             int(time.time()) - 300, int(time.time())
         )
 

--- a/django_declarative_apis/machinery/__init__.py
+++ b/django_declarative_apis/machinery/__init__.py
@@ -4,10 +4,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
-
-import itertools
-import sys
+import abc
 import http.client
+import itertools
+import logging
+import sys
 
 import django
 from django.conf import settings
@@ -15,11 +16,14 @@ from django.db import models
 from django.http import HttpResponse
 
 from django_declarative_apis.machinery.filtering import apply_filters_to_object
-from django_declarative_apis.resources.utils import HttpStatusCode
 from django_declarative_apis.models import BaseConsumer
+from django_declarative_apis.resources.utils import HttpStatusCode
 from . import errors
-from .attributes import *
-from .utils import rate_limit_exceeded, locate_object
+from .attributes import (Aggregate, ConsumerAttribute, DeferrableEndpointTask, EndpointAttribute, EndpointTask,
+                         RawRequestObjectProperty, RequestAdhocQuerySet, RequestAttribute, RequestField,
+                         RequestProperty, RequestUrlField, RequireAllAttribute, RequireAllIfAnyAttribute,
+                         RequireOneAttribute, ResourceField)
+from .utils import locate_object, rate_limit_exceeded
 
 
 # TODO:

--- a/django_declarative_apis/machinery/__init__.py
+++ b/django_declarative_apis/machinery/__init__.py
@@ -23,6 +23,9 @@ from .attributes import (Aggregate, ConsumerAttribute, DeferrableEndpointTask, E
                          RawRequestObjectProperty, RequestAdhocQuerySet, RequestAttribute, RequestField,
                          RequestProperty, RequestUrlField, RequireAllAttribute, RequireAllIfAnyAttribute,
                          RequireOneAttribute, ResourceField)
+# these imports are unusued in this file but may be used in other projects
+# that use `machinery` as an interface
+from .attributes import TypedEndpointAttributeMixin, RequestFieldGroup  # noqa
 from .utils import locate_object, rate_limit_exceeded
 
 

--- a/django_declarative_apis/machinery/attributes.py
+++ b/django_declarative_apis/machinery/attributes.py
@@ -7,7 +7,6 @@
 
 import abc
 import collections.abc
-import logging  # removing this causes problems
 import random
 import string
 import time

--- a/django_declarative_apis/machinery/attributes.py
+++ b/django_declarative_apis/machinery/attributes.py
@@ -7,7 +7,7 @@
 
 import abc
 import collections.abc
-import logging
+import logging  # removing this causes problems
 import random
 import string
 import time

--- a/django_declarative_apis/machinery/tasks.py
+++ b/django_declarative_apis/machinery/tasks.py
@@ -241,10 +241,13 @@ def schedule_future_task_runner(
     else:
         MAX_ATTEMPTS = 3
         for attempt in range(MAX_ATTEMPTS):
-            # XXX: This is an attempt to skirt around an unsolved, low repro issue somewhere in the celery/kombu/redis-py stack.
-            # Once in a while, a connection in the pool will timeout prior to a health check being called in redis-py and
-            # will result in an error being raised here. This should be removed once the issue has been sorted out.
-            # Note: This is around the use of redis-py in celery where celery's event loop is not running
+            # XXX: This is an attempt to skirt around an unsolved, low repro
+            # issue somewhere in the celery/kombu/redis-py stack.  Once in a
+            # while, a connection in the pool will timeout prior to a health
+            # check being called in redis-py and will result in an error being
+            # raised here. This should be removed once the issue has been
+            # sorted out.  Note: This is around the use of redis-py in celery
+            # where celery's event loop is not running
             # https://github.com/celery/kombu/issues/1019
             try:
                 future_task_runner.apply_async(

--- a/django_declarative_apis/resources/emitters.py
+++ b/django_declarative_apis/resources/emitters.py
@@ -5,12 +5,9 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 
-import decimal
-import re
-import inspect
-import copy
-
-from django.conf import settings
+import json
+import pickle
+from io import StringIO
 
 try:
     # yaml isn't standard with python.  It shouldn't be required if it
@@ -20,9 +17,8 @@ except ImportError:  # pragma: nocover
     yaml = None
 
 from django.db import models
-from django.utils.xmlutils import SimplerXMLGenerator
 from django.utils.encoding import smart_str
-from django.urls import reverse, NoReverseMatch
+from django.utils.xmlutils import SimplerXMLGenerator
 
 try:
     from django.core.serializers.json import (
@@ -33,14 +29,8 @@ except ImportError:
 from django.http import HttpResponse
 from django.core import serializers
 
-import json
-import types
+from .utils import HttpStatusCode, Mimer
 
-from .utils import HttpStatusCode, Mimer, locate_object
-
-from io import StringIO
-
-import pickle
 
 # Allow people to change the reverser (default `permalink`).
 reverser = models.permalink

--- a/django_declarative_apis/resources/resource.py
+++ b/django_declarative_apis/resources/resource.py
@@ -5,41 +5,28 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 
-from django.core.exceptions import ImproperlyConfigured
-
 import collections
-import json
-import sys
-import logging
 import http.client
+import json
+import logging
+import sys
 
-import django
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.core.mail import EmailMessage
+from django.http import Http404
 from django.http import (
     HttpResponse,
-    Http404,
     HttpResponseNotAllowed,
-    HttpResponseForbidden,
 )
 from django.views.debug import ExceptionReporter
 from django.views.decorators.vary import vary_on_headers
-from django.conf import settings
-from django.core.mail import send_mail, EmailMessage
-from django.db.models.query import QuerySet
-from django.http import Http404
 
-from .emitters import Emitter
-
-from django_declarative_apis.machinery import errors
 from django_declarative_apis import authentication
-from .utils import (
-    coerce_put_post,
-    FormValidationError,
-    HttpStatusCode,
-    instantiate_class,
-    locate_object,
-)
-from .utils import rc, format_error, translate_mime, MimerDataException
-
+from django_declarative_apis.machinery import errors
+from .emitters import Emitter
+from .utils import HttpStatusCode, coerce_put_post, instantiate_class, locate_object
+from .utils import MimerDataException, rc, translate_mime
 
 CHALLENGE = object()
 

--- a/django_declarative_apis/resources/utils.py
+++ b/django_declarative_apis/resources/utils.py
@@ -5,26 +5,15 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 
-import time
 import warnings
-import django
 from pydoc import locate
 
-from django.http import (
-    HttpResponseNotAllowed,
-    HttpResponseForbidden,
-    HttpResponse,
-    HttpResponseBadRequest,
-)
-from django.core.cache import cache
-from django import get_version as django_version
-from django.core.mail import send_mail, mail_admins
-from django.conf import settings
-from django.utils.translation import ugettext as _
-from django.template import loader, TemplateDoesNotExist
+import django
 from decorator import decorator
-
-from datetime import datetime, timedelta
+from django import get_version as django_version
+from django.http import (
+    HttpResponse,
+)
 
 
 def format_error(error):

--- a/tests/authentication/oauthlib/test_request_validator.py
+++ b/tests/authentication/oauthlib/test_request_validator.py
@@ -5,15 +5,11 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 
-import unittest
-
 import django.test
 import mock
 
 from django_declarative_apis import models
 from django_declarative_apis.authentication.oauthlib import request_validator
-
-from tests import testutils
 
 
 class DjangoRequestValidatorTestCase(django.test.TestCase):

--- a/tests/authentication/test_endpoint.py
+++ b/tests/authentication/test_endpoint.py
@@ -5,13 +5,11 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 
-import unittest
-
 import django.test
-from django_declarative_apis.authentication.oauthlib import endpoint, request_validator
 from django.core.cache import cache
+
 from django_declarative_apis import models
-from oauthlib.oauth1 import rfc5849
+from django_declarative_apis.authentication.oauthlib import endpoint, request_validator
 from tests import testutils
 
 

--- a/tests/filters.py
+++ b/tests/filters.py
@@ -5,7 +5,7 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 
-from django_declarative_apis.machinery.filtering import ALWAYS, NEVER, expandable
+from django_declarative_apis.machinery.filtering import ALWAYS, expandable
 
 from . import models
 

--- a/tests/machinery/test_base.py
+++ b/tests/machinery/test_base.py
@@ -5,24 +5,21 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 
+import http
 import json
 import unittest
-import mock
-import http
-import urllib.parse
 
-import kombu.exceptions
 import django.core.exceptions
-from django.db import models
-from django.core.cache import cache
 import django.test
+import kombu.exceptions
+import mock
+from django.core.cache import cache
 
+import tests.models
 from django_declarative_apis import machinery, models as dda_models
 from django_declarative_apis.machinery import errors, filtering, tasks
 from django_declarative_apis.machinery.tasks import future_task_runner
-from django_declarative_apis.resources.utils import HttpStatusCode, rc
-
-import tests.models
+from django_declarative_apis.resources.utils import HttpStatusCode
 from tests import testutils
 
 _TEST_RESOURCE = {"foo": "bar"}
@@ -306,7 +303,7 @@ class EndpointBinderTestCase(django.test.TestCase):
 
 
 class EndpointFilteringTestCase(testutils.RequestCreatorMixin, django.test.TestCase):
-    from django_declarative_apis.machinery.filtering import ALWAYS, NEVER, IF_TRUTHY
+    from django_declarative_apis.machinery.filtering import ALWAYS, NEVER
 
     class DummyClassOne(object):
         def __init__(self):

--- a/tests/resources/test_emitters.py
+++ b/tests/resources/test_emitters.py
@@ -6,17 +6,16 @@
 #
 
 import json
-import unittest
 import pickle
+import unittest
 from xml.dom import minidom
 
-import django.test
 import django.http
+import django.test
 import yaml
-from django.db import models
 
-from django_declarative_apis.resources import emitters
 import tests.models
+from django_declarative_apis.resources import emitters
 
 
 class EmitterTestCase(unittest.TestCase):

--- a/tests/resources/test_resource.py
+++ b/tests/resources/test_resource.py
@@ -71,7 +71,8 @@ class ResourceTestCase(testutils.RequestCreatorMixin, django.test.TestCase):
 
     def test_anonymous(self):
         class HandlerA:
-            anonymous = lambda: True
+            def anonymous(self):
+                return True
 
         handler = HandlerA()
         res = resource.Resource(lambda: handler)

--- a/tests/resources/test_resource.py
+++ b/tests/resources/test_resource.py
@@ -7,16 +7,14 @@
 
 import http
 import json
-import unittest
 
-import django.test
 import django.conf
 import django.core.exceptions
+import django.test
 import mock
 
-from django_declarative_apis import models
-from django_declarative_apis.resources import resource
 from django_declarative_apis.authentication.oauthlib import oauth_errors
+from django_declarative_apis.resources import resource
 from tests import testutils
 
 

--- a/tests/resources/test_utils.py
+++ b/tests/resources/test_utils.py
@@ -9,16 +9,13 @@ import http
 import json
 import unittest
 
-import mock
 import django.test
+import mock
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from django_declarative_apis.resources import utils
-
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives import serialization
-
-from tests import testutils
 
 
 class UtilsTestCase(unittest.TestCase):

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -7,9 +7,10 @@
 
 import http
 import unittest
-import mock
+
 import django.test
-from django_declarative_apis import adapters, machinery, authentication
+
+from django_declarative_apis import adapters, authentication, machinery
 
 
 class BaseHandlerTestCase(unittest.TestCase):

--- a/tests/views.py
+++ b/tests/views.py
@@ -5,8 +5,6 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 
-from django.http import HttpResponse
-
 from django_declarative_apis.machinery import EndpointDefinition, field
 
 


### PR DESCRIPTION
* Don't import from `*` in `machinery.__init__`

This one might be a bit controversial.  The `import *` is replaced with a pretty long list of imports, but the `*` import obscured the fact that some base things like `logging` and `abc` weren't being imported in `machinery.__init__`, they were coming in from the `attributes` module.  There are a few attributes that aren't explicitly imported here that I could add to the list if the intention is for this module to be an interface that subsumes `attributes`.

* Remove unnecessary imports and sort them (PyCharm's "optimize imports")
* Wrap a couple of long lines
* Remove an unnecessary lambda