### PR TITLE
Update to Django 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - [PR 21](https://github.com/salesforce/django-declarative-apis/pull/21) Add Makefile targets for Black formatter
 - [PR 22](https://github.com/salesforce/django-declarative-apis/pull/22) Format code with Black
 
+### Changed
+- [PR 28](https://github.com/salesforce/django-declarative-apis/pull/28) Require Django 2.2
+
 ### Fixed
 - [PR 18](https://github.com/salesforce/django-declarative-apis/pull/18) Bump PyYaml dev requirement version
 - [PR 19](https://github.com/salesforce/django-declarative-apis/pull/19) Bump required Django patch version

--- a/django_declarative_apis/resources/emitters.py
+++ b/django_declarative_apis/resources/emitters.py
@@ -42,9 +42,6 @@ from io import StringIO
 
 import pickle
 
-# Allow people to change the reverser (default `permalink`).
-reverser = models.permalink
-
 
 class Emitter(object):
     """

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,3 +1,3 @@
 ../../django-declarative-apis
-Django~=2.0.0
+Django~=2.1.0
 django-sslserver==0.20

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,3 +1,3 @@
 ../../django-declarative-apis
-Django~=1.11.28
+Django~=2.0.0
 django-sslserver==0.20

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,3 +1,3 @@
 ../../django-declarative-apis
-Django~=2.1.0
+Django~=2.2.0
 django-sslserver==0.20

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,5 @@ mock==2.0.0
 oauth2==1.9.0.post1
 pyyaml~=5.3
 sphinx_rtd_theme==0.4.2
+tblib~=1.6.0
 tox==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django~=1.11.28
+Django~=2.0.0
 celery>=4.0.2,<=4.4.0,!=4.1.0
 cryptography>=2.0,<=2.6
 decorator==4.0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django~=2.1.0
+Django~=2.2.0
 celery>=4.0.2,<=4.4.0,!=4.1.0
 cryptography>=2.0,<=2.6
 decorator==4.0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django~=2.0.0
+Django~=2.1.0
 celery>=4.0.2,<=4.4.0,!=4.1.0
 cryptography>=2.0,<=2.6
 decorator==4.0.11

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -167,7 +167,7 @@ class OAuthClientHandler(ClientHandler):
                 oauth_request.sign_request(signature_method, consumer, None)
                 oauth_signature_data["oauth_signature"] = oauth_request.get_parameter(
                     "oauth_signature"
-                )
+                ).decode('utf-8')
 
             use_auth_header_signature = request.META.pop(
                 "use_auth_header_signature", False


### PR DESCRIPTION
* Bump Django to 2.0 - no changes needed
* Bump Django to 2.1
  * Remove unneeded use of deprecated `models.permalink`
  * "Invalid Signature" error on POST in test: It looks like Django's `urlencode()` behavior changed for `bytes`, and this is messing up the `oauth_signature` generated by `oauth2` (only used in testing): 
    * https://code.djangoproject.com/ticket/28679
    * https://docs.djangoproject.com/en/3.0/releases/2.0/#removed-support-for-bytestrings-in-some-places
* Bump Django to 2.2 - no changes needed