### PR TITLE
Fix flake8 warnings in example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - [PR 23](https://github.com/salesforce/django-declarative-apis/pull/23) Fix some flake8 warnings
 - [PR 26](https://github.com/salesforce/django-declarative-apis/pull/26) Use yaml.safe_load in test
 - [PR 27](https://github.com/salesforce/django-declarative-apis/pull/27) Fix more flake8 warnings
+- [PR 29](https://github.com/salesforce/django-declarative-apis/pull/29) Ignore unused imports in example
 
 # [0.19.3] - 2020-02-04
 - Increase celery version range

--- a/example/myapp/admin.py
+++ b/example/myapp/admin.py
@@ -5,6 +5,6 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 
-from django.contrib import admin
+from django.contrib import admin  # noqa
 
 # Register your models here.

--- a/example/myapp/tests.py
+++ b/example/myapp/tests.py
@@ -5,6 +5,6 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 
-from django.test import TestCase
+from django.test import TestCase  # noqa
 
 # Create your tests here.

--- a/example/myapp/views.py
+++ b/example/myapp/views.py
@@ -5,6 +5,6 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 
-from django.shortcuts import render
+from django.shortcuts import render  # noqa
 
 # Create your views here.


### PR DESCRIPTION
Ignore specific "unused imports" in the example.  They're in files meant to be empty templates.