### PR TITLE
Use the test-all target with TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 install:
   - make install
 script:
-  - make test
+  - make test-all
 deploy:
   provider: pypi
   user: __token__

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ readme:
 
 # Test targets
 
-test-all: coverage static vuln-static formatcheck
+test-all: coverage vuln-static formatcheck
 .PHONY: test-all
 
 test:

--- a/django_declarative_apis/authentication/oauthlib/oauth_errors.py
+++ b/django_declarative_apis/authentication/oauthlib/oauth_errors.py
@@ -23,8 +23,10 @@ class OAuthTimestampError(OAuthError):
         )
         start_time = int(time.time()) - 300
         end_time = int(time.time())
-        self.auth_header = ('OAuth realm="API",oauth_problem=timestamp_refused'
-                            f'&oauth_acceptable_timestamps={start_time}-{end_time}')
+        self.auth_header = (
+            'OAuth realm="API",oauth_problem=timestamp_refused'
+            f"&oauth_acceptable_timestamps={start_time}-{end_time}"
+        )
 
 
 class OAuthMissingParameterError(OAuthError):

--- a/django_declarative_apis/machinery/__init__.py
+++ b/django_declarative_apis/machinery/__init__.py
@@ -19,10 +19,24 @@ from django_declarative_apis.machinery.filtering import apply_filters_to_object
 from django_declarative_apis.models import BaseConsumer
 from django_declarative_apis.resources.utils import HttpStatusCode
 from . import errors
-from .attributes import (Aggregate, ConsumerAttribute, DeferrableEndpointTask, EndpointAttribute, EndpointTask,
-                         RawRequestObjectProperty, RequestAdhocQuerySet, RequestAttribute, RequestField,
-                         RequestProperty, RequestUrlField, RequireAllAttribute, RequireAllIfAnyAttribute,
-                         RequireOneAttribute, ResourceField)
+from .attributes import (
+    Aggregate,
+    ConsumerAttribute,
+    DeferrableEndpointTask,
+    EndpointAttribute,
+    EndpointTask,
+    RawRequestObjectProperty,
+    RequestAdhocQuerySet,
+    RequestAttribute,
+    RequestField,
+    RequestProperty,
+    RequestUrlField,
+    RequireAllAttribute,
+    RequireAllIfAnyAttribute,
+    RequireOneAttribute,
+    ResourceField,
+)
+
 # these imports are unusued in this file but may be used in other projects
 # that use `machinery` as an interface
 from .attributes import TypedEndpointAttributeMixin, RequestFieldGroup  # noqa

--- a/django_declarative_apis/resources/emitters.py
+++ b/django_declarative_apis/resources/emitters.py
@@ -32,7 +32,6 @@ from django.core import serializers
 from .utils import HttpStatusCode, Mimer
 
 
-
 class Emitter(object):
     """
     Super emitter. All other emitters should subclass

--- a/django_declarative_apis/resources/resource.py
+++ b/django_declarative_apis/resources/resource.py
@@ -15,10 +15,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import EmailMessage
 from django.http import Http404
-from django.http import (
-    HttpResponse,
-    HttpResponseNotAllowed,
-)
+from django.http import HttpResponse, HttpResponseNotAllowed
 from django.views.debug import ExceptionReporter
 from django.views.decorators.vary import vary_on_headers
 

--- a/django_declarative_apis/resources/utils.py
+++ b/django_declarative_apis/resources/utils.py
@@ -11,9 +11,7 @@ from pydoc import locate
 import django
 from decorator import decorator
 from django import get_version as django_version
-from django.http import (
-    HttpResponse,
-)
+from django.http import HttpResponse
 
 
 def format_error(error):

--- a/tests/machinery/test_base.py
+++ b/tests/machinery/test_base.py
@@ -356,9 +356,11 @@ class EndpointFilteringTestCase(testutils.RequestCreatorMixin, django.test.TestC
 
     def test_filter_inheritance_with_mixin(self):
         data = EndpointFilteringTestCase.DummyClassTwo()
-        filtered_data = filtering.apply_filters_to_object(data, EndpointFilteringTestCase.TEST_FILTERS)
-        self.assertTrue('foo' in filtered_data)
-        self.assertTrue('bar' in filtered_data)
+        filtered_data = filtering.apply_filters_to_object(
+            data, EndpointFilteringTestCase.TEST_FILTERS
+        )
+        self.assertTrue("foo" in filtered_data)
+        self.assertTrue("bar" in filtered_data)
 
     def test_filter_large_collection(self):
         data = [EndpointFilteringTestCase.DummyClassFour() for _ in range(1000)]

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -167,7 +167,7 @@ class OAuthClientHandler(ClientHandler):
                 oauth_request.sign_request(signature_method, consumer, None)
                 oauth_signature_data["oauth_signature"] = oauth_request.get_parameter(
                     "oauth_signature"
-                ).decode('utf-8')
+                ).decode("utf-8")
 
             use_auth_header_signature = request.META.pop(
                 "use_auth_header_signature", False


### PR DESCRIPTION
Have TravisCI run `test-all` (`coverage`, `vuln-static`, and `formatcheck`) instead of just `test`.

I've removed the `static` target from the `test-all` target for now, because there are still outstanding flake8 errors.

Also, format the codebase with black again.  Since it hasn't been a requirement, the code didn't pass `formatcheck` anymore.