### PR TITLE
Release/v0.20.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.19.3
+current_version = 0.20.0
 
 [bumpversion:file:setup.py]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-# []
+# [0.20.0] - 2020-03-09
 ### Added
 - [PR 21](https://github.com/salesforce/django-declarative-apis/pull/21) Add Makefile targets for Black formatter
 - [PR 22](https://github.com/salesforce/django-declarative-apis/pull/22) Format code with Black
+- [PR 34](https://github.com/salesforce/django-declarative-apis/pull/34) Test coverage, vulnerabilities, and format with TravisCI
 
 ### Changed
 - [PR 28](https://github.com/salesforce/django-declarative-apis/pull/28) Require Django 2.2
@@ -22,6 +23,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - [PR 26](https://github.com/salesforce/django-declarative-apis/pull/26) Use yaml.safe_load in test
 - [PR 27](https://github.com/salesforce/django-declarative-apis/pull/27) Fix more flake8 warnings
 - [PR 29](https://github.com/salesforce/django-declarative-apis/pull/29) Ignore unused imports in example
+- [PR 33](https://github.com/salesforce/django-declarative-apis/pull/33) Fix filters for classes with mixins
 
 # [0.19.3] - 2020-02-04
 - Increase celery version range

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,7 @@ author = 'Salesforce'
 # built documents.
 
 # The full version, including alpha/beta/rc tags.
-release = '0.19.3'
+release = '0.20.0'
 
 # The short X.Y version.
 version = release.rsplit('.', 1)[0]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,7 @@ author = 'Salesforce'
 # built documents.
 
 # The full version, including alpha/beta/rc tags.
-release = '0.20.0'
+release = '0.20.0'  # set by bumpversion
 
 # The short X.Y version.
 version = release.rsplit('.', 1)[0]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(path.dirname(__file__), "requirements.txt")) as requirements
 
 setuptools.setup(
     name="django-declarative-apis",
-    version="0.20.0",
+    version="0.20.0",  # set by bumpversion
     author="Drew Shafer",
     url="https://salesforce.com",
     description="Simple, readable, declarative APIs for Django",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(path.dirname(__file__), "requirements.txt")) as requirements
 
 setuptools.setup(
     name="django-declarative-apis",
-    version="0.19.3",
+    version="0.20.0",
     author="Drew Shafer",
     url="https://salesforce.com",
     description="Simple, readable, declarative APIs for Django",


### PR DESCRIPTION
Main changes are:
* Update Django requirement to 2.2
* Fix filters for classes with mixins
* Fix of lots of flake8, deprecation, and Github security warnings
* Format the codebase with Black