### PR TITLE
Add safety requirement and Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ TEST_WARNINGS_CMD = ${PYTHON} -Wa manage.py test
 COVERAGE_CMD = coverage run manage.py test --noinput && coverage xml && coverage report
 STATIC_CMD = flake8 ${PACKAGE_DIR} ${TEST_DIR} ${EXAMPLE_DIR} setup.py
 VULN_STATIC_CMD = bandit -r -ii -ll -x ${PACKAGE_DIR}/migrations ${PACKAGE_DIR} 
+VULN_DEPS_CMD = safety check --full-report
 FORMAT_CMD = black ${PACKAGE_DIR} ${TEST_DIR} ${EXAMPLE_DIR} setup.py
 FORMATCHECK_CMD = ${FORMAT_CMD} --check
 
@@ -34,7 +35,7 @@ readme:
 
 # Test targets
 
-test-all: coverage vuln-static formatcheck
+test-all: coverage vuln-static vuln-deps formatcheck
 .PHONY: test-all
 
 test:
@@ -56,6 +57,10 @@ static:
 vuln-static:
 	${VULN_STATIC_CMD}
 .PHONY: vuln-static
+
+vuln-deps:
+	${VULN_DEPS_CMD}
+.PHONY: vuln-deps
 
 formatcheck:
 	${FORMATCHECK_CMD}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ ipython==4.2.1
 mock==2.0.0
 oauth2==1.9.0.post1
 pyyaml~=5.3
+safety~=1.8.5
 sphinx_rtd_theme==0.4.2
 tblib~=1.6.0
 tox==2.6.0


### PR DESCRIPTION
Do we want to use safety, or are GitHub's checks enough?

This PR adds a dev-requirement for safety, adds a Makefile target to run it, and adds this target to test-all.