### PR TITLE
Feature/allow renaming expandable foreign keys

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.20.0
+current_version = 0.21.0
 
 [bumpversion:file:setup.py]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-# [Unrelased]
+# [0.21.0]
+### Added
+- [PR 42](https://github.com/salesforce/django-declarative-apis/pull/42) Add inst_field_name to expandable fields
 ### Changed
 - [PR 39](https://github.com/salesforce/django-declarative-apis/pull/39) Add long_description to setup 
 - [PR 40](https://github.com/salesforce/django-declarative-apis/pull/40) Remove use of root logger

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(path.join(HERE, "README.md")) as readme_file:
 
 setuptools.setup(
     name="django-declarative-apis",
-    version="0.20.0",  # set by bumpversion
+    version="0.21.0",  # set by bumpversion
     author="Drew Shafer",
     url="https://salesforce.com",
     description="Simple, readable, declarative APIs for Django",

--- a/tests/filters.py
+++ b/tests/filters.py
@@ -38,6 +38,34 @@ DEFAULT_FILTERS = {
     },
 }
 
+RENAMED_EXPANDABLE_MODEL_FIELDS = {
+    str: ALWAYS,
+    int: ALWAYS,
+    dict: ALWAYS,
+    models.TestModel: {
+        "pk": ALWAYS,
+        "int_field": ALWAYS,
+        "renamed_expandable_dict": expandable(inst_field_name="expandable_dict"),
+        "renamed_expandable_string": expandable(inst_field_name="expandable_string"),
+    },
+    models.ParentModel: {
+        "nonstandard_id": ALWAYS,
+        "name": ALWAYS,
+        "favorite": expandable(model_class=models.ChildModel, display_key="name"),
+        "children": expandable(model_class=models.ChildModel, display_key="name"),
+    },
+    models.ChildModel: {
+        "pk": ALWAYS,
+        "renamed_test": expandable(
+            model_class=models.TestModel, inst_field_name="test"
+        ),
+        "name": ALWAYS,
+        "renamed_parent": expandable(
+            model_class=models.ParentModel, inst_field_name="parent"
+        ),
+    },
+}
+
 DEFAULT_FILTERS_NO_EXPANDABLE = {
     str: ALWAYS,
     int: ALWAYS,


### PR DESCRIPTION
Ran into an issue where I wanted the name of an expandable field to be different than the name of the field on the underlying model

Fixes #41 