### PR TITLE
chore: update cryptography and coverage dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [0.22.3] - 2021-05-18
+# [unreleased] - YYYY-MM-DD
 ### Fixed
 - [PR 55](https://github.com/salesforce/django-declarative-apis/pull/55) Backwards compatibility fix for field expansion headers, update example app
 
+### Changed
+- [PR 52](https://github.com/salesforce/django-declarative-apis/pull/52) Update cryptography and coverage dependencies
+
 # [0.22.2] - 2020-08-11
 ### Fixed
-- [PR](https://github.com/salesforce/django-declarative-apis/pull/48) Apply filters to dict values
+- [PR 48](https://github.com/salesforce/django-declarative-apis/pull/48) Apply filters to dict values
 
 # [0.22.1] - 2020-08-11
 ### Fixed
-- [PR]() Fix travis config
+- [PR 46](https://github.com/salesforce/django-declarative-apis/pull/46) Fix travis config
 
 # [0.22.0] - 2020-08-11
 ### Added

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 bandit~=1.6
 black==19.3b0
 bumpversion~=0.5
-coverage==4.3.4
+coverage~=5.0
 flake8~=3.7.0
 ipython==4.2.1
 mock==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django~=2.2.0
 celery>=4.0.2,<=4.4.0,!=4.1.0
-cryptography>=2.0,<=2.6
+cryptography>=2.0,<=3.4.7
 decorator==4.0.11
 django-dirtyfields>=1.2.1
 oauthlib[signedtoken,rsa]>=2.0.6,<3.1.0


### PR DESCRIPTION
Expand the allowable range of the `cryptography` dependency to include the latest (3.4.7).

Also update the `coverage` dev dependency to ~5.0, because it's giving me an error locally.

This attempts to address the Snyk warning (#51) as well.