### PR TITLE
chore: remove "mock" dev dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 - [PR 52](https://github.com/salesforce/django-declarative-apis/pull/52) Update cryptography and coverage dependencies
 - [PR 53](https://github.com/salesforce/django-declarative-apis/pull/53) Update dev dependencies: flake8, bandit, ipython
+- [PR 54](https://github.com/salesforce/django-declarative-apis/pull/54) Remove unneeded `mock` dependency
 
 # [0.22.2] - 2020-08-11
 ### Fixed

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ bumpversion~=0.5
 coverage~=5.0
 flake8~=3.7.0
 ipython==4.2.1
-mock==2.0.0
 oauth2==1.9.0.post1
 pyyaml~=5.3
 sphinx_rtd_theme==0.4.2

--- a/tests/authentication/oauthlib/test_oauth1.py
+++ b/tests/authentication/oauthlib/test_oauth1.py
@@ -11,7 +11,7 @@ import unittest
 
 import django.test
 import django.http
-import mock
+from unittest import mock
 
 from django_declarative_apis import models
 from django_declarative_apis import authentication

--- a/tests/authentication/oauthlib/test_request_validator.py
+++ b/tests/authentication/oauthlib/test_request_validator.py
@@ -6,7 +6,7 @@
 #
 
 import django.test
-import mock
+from unittest import mock
 
 from django_declarative_apis import models
 from django_declarative_apis.authentication.oauthlib import request_validator

--- a/tests/machinery/test_base.py
+++ b/tests/machinery/test_base.py
@@ -12,7 +12,7 @@ import unittest
 import django.core.exceptions
 import django.test
 import kombu.exceptions
-import mock
+from unittest import mock
 from django.core.cache import cache
 from django.http import HttpRequest
 

--- a/tests/resources/test_resource.py
+++ b/tests/resources/test_resource.py
@@ -11,7 +11,7 @@ import json
 import django.conf
 import django.core.exceptions
 import django.test
-import mock
+from unittest import mock
 
 from django_declarative_apis.authentication.oauthlib import oauth_errors
 from django_declarative_apis.resources import resource

--- a/tests/resources/test_utils.py
+++ b/tests/resources/test_utils.py
@@ -10,7 +10,7 @@ import json
 import unittest
 
 import django.test
-import mock
+from unittest import mock
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -6,7 +6,7 @@
 #
 
 import django.test
-import mock
+from unittest import mock
 
 from django_declarative_apis.machinery import filtering
 


### PR DESCRIPTION
Remove dev dependency on [mock](https://pypi.org/project/mock/): Mock is a backport library for functionality that exists in Python 3.

Update the tests that use `mock` to use `unittest.mock`.