### PR TITLE
chore: Upgrade pip as part of `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ FORMATCHECK_CMD = ${FORMAT_CMD} --check
 
 
 install:
-	pip install -r requirements.txt -r requirements-dev.txt
+	pip install --upgrade pip -r requirements.txt -r requirements-dev.txt
 .PHONY: install
 
 format:


### PR DESCRIPTION
pip 21 is more strict due to its dependency resolver.  We should ensure that we're using the latest pip when we install and test locally.