### PR TITLE
Allow Celery 5 by using `shared_task`

### DIFF
--- a/django_declarative_apis/machinery/tasks.py
+++ b/django_declarative_apis/machinery/tasks.py
@@ -7,7 +7,7 @@
 
 import logging
 from pydoc import locate
-from celery.task import task as celery_task
+from celery import shared_task as celery_task
 import celery
 import time
 from typing import NamedTuple

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django~=2.2.0
-celery>=4.0.2,<=4.4.0,!=4.1.0
+celery>=4.0.2
 cryptography>=2.0,<=3.4.8
 decorator==4.0.11
 django-dirtyfields>=1.2.1


### PR DESCRIPTION
Replacing `celery.task` with `celery.shared_task` seems to fix the tests
on Celery 5 (they continue to work with Celery 4 as well).

I don't know enough about Celery to be sure this is the right fix, but
I'm going off of this:

> If you’re using Django (see First steps with Django), or you’re the
> author of a library then you probably want to use the shared_task()
> decorator:

https://docs.celeryproject.org/en/stable/userguide/tasks.html
