### PR TITLE
Don't drop support for Django 2.2 until consumers catch up

### DIFF
--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,5 +1,5 @@
 ../../django-declarative-apis
-Django~=3.2
+Django >=2.2, <4
 django-sslserver==0.20
 oauth2==1.9.0.post1
 oauthlib==2.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django~=3.2
+Django >=2.2, <4
 celery>=4.0.2,!=4.1.0
 cryptography>=2.0,<=3.4.8
 decorator==4.0.11


### PR DESCRIPTION
Let's support both Django 2.2 and 3.2 until consumers of this package catch up.