### PR TITLE
chore: remove spaces in name of `test` GitHub Action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: unit tests and static analysis
+name: unit-tests-and-static-analysis
 
 on: [push, pull_request]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [unreleased] - YYYY-MM-DD
-
 ### Added
 - [PR 94](https://github.com/salesforce/django-declarative-apis/pull/94) Add a Pull Request template/checklist to the repo
 - [PR 92](https://github.com/salesforce/django-declarative-apis/pull/92) Run tests and static analysis as a PR check using GitHub actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [unreleased] - YYYY-MM-DD
+### Changed
+- [PR 93](https://github.com/salesforce/django-declarative-apis/pull/93) Remove spaces in name of `test` GitHub Action
 
 # [0.22.3] - 2021-11-18
 ### Added 


### PR DESCRIPTION
GitHub likes names without spaces better.

The GitHub Action works as it is currently names, but the PR check doesn't show up correctly in the branch protection dropdown.
