### PR TITLE
feat: Small updates for ReadTheDocs integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [unreleased] - YYYY-MM-DD
 ### Added
+- [PR 96](https://github.com/salesforce/django-declarative-apis/pull/96) Minor tweaks for ReadTheDocs integration
 - [PR 94](https://github.com/salesforce/django-declarative-apis/pull/94) Add a Pull Request template/checklist to the repo
 - [PR 92](https://github.com/salesforce/django-declarative-apis/pull/92) Run tests and static analysis as a PR check using GitHub actions
 - [PR 83](https://github.com/salesforce/django-declarative-apis/pull/83) Allow Django 3

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Documentation Status](https://readthedocs.org/projects/django-declarative-apis/badge/?version=stable)](https://django-declarative-apis.readthedocs.io/en/stable/?badge=stable)
+
+
 Overview
 ========
 
@@ -9,8 +12,6 @@ django-declarative-apis is a framework built on top of Django aimed at teams imp
 -   Define resource and endpoint-bound tasks, promoting modularity
     \* Define synchronous and asynchronous tasks (asynchronous tasks implemented with Celery)
 -   Separation of concerns between request body processing and business logic
-
-
 
 
 Quick start

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to django-declarative-apis's documentation!
-===================================================
+Django Declarative APIs v\ |version|
+====================================
 
 .. include:: overview.rst
 


### PR DESCRIPTION
Add a docs badge to the README and make the docs title a little nicer.

See published docs at https://django-declarative-apis.readthedocs.io/en/stable/

- [x] Update CHANGELOG.md
- [x] Update README.md (as needed)
- [x] New dependencies were added to `requirements.txt` or `requirements-dev.txt`
- [x] `pip install` succeeds with a clean virtualenv
- [x] There are new or modified tests that cover changes
- [x] Test coverage is maintained or expanded