### PR TITLE
chore: Improve errors.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [unreleased] - XXXX-XX-XX
+### Added
+- [PR 100](https://github.com/salesforce/django-declarative-apis/pull/100) Let ServerError take an `extra_message` argument
+
 # [0.23.1] - 2022-05-17
 ### Fixed
 - [PR 98](https://github.com/salesforce/django-declarative-apis/pull/98) Fix GitHub publish action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [unreleased] - XXXX-XX-XX
 ### Added
-- [PR 100](https://github.com/salesforce/django-declarative-apis/pull/100) Let ServerError take an `extra_message` argument
+- [PR 100](https://github.com/salesforce/django-declarative-apis/pull/100) Improve `errors.py`
 
 # [0.23.1] - 2022-05-17
 ### Fixed

--- a/django_declarative_apis/machinery/errors.py
+++ b/django_declarative_apis/machinery/errors.py
@@ -75,9 +75,7 @@ class ApiError(Exception):
             return self.__dict__["error_code"]
         except KeyError:
             raise AttributeError(
-                "'{}' object has no attribute '{}'".format(
-                    ApiError.__name__, "error_code"
-                )
+                f"'{ApiError.__name__}' object has no attribute 'error_code'"
             )
 
     @error_code.setter
@@ -113,7 +111,7 @@ class ClientErrorNotFound(ClientError):
             http.client.responses.get(http.client.NOT_FOUND),
         )
         if additional_info:
-            error_message += " : " + additional_info
+            error_message += f" : {additional_info}"
         super().__init__(
             error_code, error_message, http_status_code=http.client.NOT_FOUND
         )
@@ -123,7 +121,7 @@ class ClientErrorForbidden(ClientError):
     def __init__(self, additional_info=None, **kwargs):
         error_code, error_message = FORBIDDEN
         if additional_info:
-            error_message += ": %s" % additional_info
+            error_message += f": {additional_info}"
         super().__init__(
             error_code, error_message, http_status_code=http.client.FORBIDDEN, **kwargs
         )
@@ -147,7 +145,7 @@ class ClientErrorExternalServiceFailure(ClientError):
     def __init__(self, additional_info=None):
         error_code, error_message = EXTERNAL_REQUEST_FAILURE
         if additional_info:
-            error_message += ": {0}".format(additional_info)
+            error_message += f": {additional_info}"
         super().__init__(error_code, error_message)
 
 
@@ -161,7 +159,7 @@ class ClientErrorTimedOut(ClientError):
     def __init__(self, additional_info=None):
         error_code, error_message = TIMED_OUT
         if additional_info:
-            error_message += ": %s" % additional_info
+            error_message += f": {additional_info}"
         super().__init__(
             error_code, error_message, http_status_code=http.client.REQUEST_TIMEOUT
         )
@@ -179,7 +177,7 @@ class ClientErrorExtraFields(ClientError):
     def __init__(self, extra_fields=None):
         error_code, error_message = EXTRA_FIELDS
         if extra_fields:
-            error_message += ": %s" % ", ".join(extra_fields)
+            error_message += f": {', '.join(extra_fields)}"
         super().__init__(error_code, error_message)
 
 
@@ -187,7 +185,7 @@ class ClientErrorReadOnlyFields(ClientError):
     def __init__(self, read_only_fields=None):
         error_code, error_message = READ_ONLY_FIELDS
         if read_only_fields:
-            error_message += ": %s" % ", ".join(read_only_fields)
+            error_message += f": {', '.join(read_only_fields)}"
         super().__init__(error_code, error_message)
 
 
@@ -195,9 +193,9 @@ class ClientErrorMissingFields(ClientError):
     def __init__(self, missing_fields=None, extra_message=None):
         error_code, error_message = MISSING_FIELDS
         if missing_fields:
-            error_message += ": %s" % ", ".join(missing_fields)
+            error_message += f": {', '.join(missing_fields)}"
         if extra_message:
-            error_message += ": {0}".format(extra_message)
+            error_message += f": {extra_message}"
         super().__init__(error_code, error_message)
 
 
@@ -205,9 +203,9 @@ class ClientErrorInvalidFieldValues(ClientError):
     def __init__(self, invalid_fields=None, extra_message=None):
         error_code, error_message = INVALID_FIELD_VALUES
         if invalid_fields:
-            error_message += ": %s" % ", ".join(invalid_fields)
+            error_message += f": {', '.join(invalid_fields)}"
         if extra_message:
-            error_message += ": {0}".format(extra_message)
+            error_message += f": {extra_message}"
         super().__init__(error_code, error_message)
 
 

--- a/django_declarative_apis/machinery/errors.py
+++ b/django_declarative_apis/machinery/errors.py
@@ -77,7 +77,7 @@ class ApiError(Exception):
         except KeyError:
             raise AttributeError(
                 f"'{ApiError.__name__}' object has no attribute 'error_code'"
-            )
+            ) from None  # suppress reporting the KeyError
 
     @error_code.setter
     def error_code(self, value):

--- a/django_declarative_apis/machinery/errors.py
+++ b/django_declarative_apis/machinery/errors.py
@@ -12,7 +12,8 @@ import warnings
 
 import http.client
 
-# Start Toopher-specific codes at 600 to avoid conflict/confusion with HTTP status codes
+
+# Start DDA-specific codes at 600 to avoid conflict/confusion with HTTP status codes
 import sys
 
 logger = logging.getLogger(__name__)

--- a/django_declarative_apis/machinery/errors.py
+++ b/django_declarative_apis/machinery/errors.py
@@ -212,9 +212,11 @@ class ClientErrorInvalidFieldValues(ClientError):
 
 
 class ServerError(ApiError):
-    def __init__(self):
+    def __init__(self, extra_message=None):
         error_code, error_message = LOGGED_SERVER_ERROR
         error_message = error_message.format(uuid.uuid4())
+        if extra_message:
+            error_message += f": {extra_message}"
         logger.exception(error_message)
 
         self._cause = None

--- a/django_declarative_apis/machinery/errors.py
+++ b/django_declarative_apis/machinery/errors.py
@@ -173,7 +173,7 @@ class ClientErrorTimedOut(ClientError):
 class ClientErrorResponseWrapper(ClientError):
     def __init__(self, response):
         error_code = response.status_code
-        error_message = response.content
+        error_message = response.content.decode()
         status_code = response.status_code
         super().__init__(error_code, error_message, http_status_code=status_code)
 

--- a/django_declarative_apis/machinery/errors.py
+++ b/django_declarative_apis/machinery/errors.py
@@ -215,11 +215,11 @@ class ClientErrorInvalidFieldValues(ClientError):
 
 
 class ServerError(ApiError):
-    def __init__(self, extra_message=None):
+    def __init__(self, additional_info=None):
         error_code, error_message = LOGGED_SERVER_ERROR
         error_message = error_message.format(uuid.uuid4())
-        if extra_message:
-            error_message += f": {extra_message}"
+        if additional_info:
+            error_message += f": {additional_info}"
         logger.exception(error_message)
 
         self._cause = None

--- a/django_declarative_apis/machinery/errors.py
+++ b/django_declarative_apis/machinery/errors.py
@@ -112,7 +112,7 @@ class ClientErrorNotFound(ClientError):
             http.client.responses.get(http.client.NOT_FOUND),
         )
         if additional_info:
-            error_message += f" : {additional_info}"
+            error_message += f": {additional_info}"
         super().__init__(
             error_code, error_message, http_status_code=http.client.NOT_FOUND
         )

--- a/django_declarative_apis/machinery/errors.py
+++ b/django_declarative_apis/machinery/errors.py
@@ -217,10 +217,10 @@ class ClientErrorInvalidFieldValues(ClientError):
 class ServerError(ApiError):
     def __init__(self, additional_info=None):
         error_code, error_message = LOGGED_SERVER_ERROR
-        error_message = error_message.format(uuid.uuid4())
+        logged_error = error_message = error_message.format(uuid.uuid4())
         if additional_info:
-            error_message += f": {additional_info}"
-        logger.exception(error_message)
+            logged_error += f": {additional_info}"
+        logger.exception(logged_error)
 
         self._cause = None
 

--- a/django_declarative_apis/machinery/errors.py
+++ b/django_declarative_apis/machinery/errors.py
@@ -152,7 +152,11 @@ class ClientErrorExternalServiceFailure(ClientError):
 class ClientErrorRequestThrottled(ClientError):
     def __init__(self):
         error_code, error_message = REQUEST_THROTTLED
-        super().__init__(error_code, error_message, http_status_code=429)
+        super().__init__(
+            error_code,
+            error_message,
+            http_status_code=http.HTTPStatus.TOO_MANY_REQUESTS,
+        )
 
 
 class ClientErrorTimedOut(ClientError):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -84,7 +84,7 @@ version = release.rsplit('.', 1)[0]
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,5 +23,5 @@ exclude = '''
 omit = ["*/tests/*", "*/management/*", "*/migrations/*"]
 
 [tool.coverage.report]
-fail_under = 88
+fail_under = 91
 exclude_lines = ["raise NotImplementedError"]

--- a/tests/machinery/test_base.py
+++ b/tests/machinery/test_base.py
@@ -78,7 +78,7 @@ class EndpointResourceAttributeTestCase(
             self.fail("This should have failed")
         except errors.ClientErrorNotFound as err:
             self.assertEqual(err.error_code, http.HTTPStatus.NOT_FOUND)
-            self.assertEqual(err.error_message, "Not Found : dict instance not found")
+            self.assertEqual(err.error_message, "Not Found: dict instance not found")
             self.assertEqual(err.status_code, http.HTTPStatus.NOT_FOUND)
             self.assertFalse(err.save_changes)
             self.assertEqual(err.extra_fields, {})

--- a/tests/machinery/test_errors.py
+++ b/tests/machinery/test_errors.py
@@ -2,23 +2,24 @@ import django.test
 
 from django_declarative_apis.machinery import errors
 
-class ApiErrorTestCase(django.test.TestCase):
 
-    def test_tuple(self):
+class ErrorTestCast(django.test.TestCase):
+
+    def test_apierror_tuple(self):
         test_code, test_message = test_tuple = errors.HTTPS_REQUIRED
         err = errors.ApiError(error_tuple=test_tuple)
-        self.assertEqual(err.error_code, test_code)
-        self.assertEqual(err.error_message, test_message)
+        self.assertEqual(test_code, err.error_code)
+        self.assertEqual(test_message, err.error_message)
         self.assertDictEqual(err.as_dict(), dict(error_code=test_code, error_message=test_message))
 
-    def test_code_and_message(self):
+    def test_apierror_code_and_message(self):
         test_code, test_message = 600, "test message"
         err = errors.ApiError(code=test_code, message=test_message)
-        self.assertEqual(err.error_code, test_code)
-        self.assertEqual(err.error_message, test_message)
-        self.assertDictEqual(err.as_dict(), dict(error_code=test_code, error_message=test_message))
+        self.assertEqual(test_code, err.error_code)
+        self.assertEqual(test_message, err.error_message)
+        self.assertDictEqual(dict(error_code=test_code, error_message=test_message), err.as_dict())
 
-    def test_bad_args(self):
+    def test_apierror_bad_args(self):
         try:
             errors.ApiError()
         except errors.ApiError:
@@ -29,8 +30,19 @@ class ApiErrorTestCase(django.test.TestCase):
         else:
             self.fail("ApiError without arguments should raise an exception.")
 
-    def test_extra_args(self):
+    def test_apierror_extra_args(self):
         test_code, test_message = test_tuple = errors.AUTHORIZATION_FAILURE
         err = errors.ApiError(error_tuple=test_tuple, foo="bar", baz="quux")
-        self.assertDictEqual(err.as_dict(),
-                             dict(error_code=test_code, error_message=test_message, foo="bar", baz="quux"))
+        self.assertDictEqual(dict(error_code=test_code, error_message=test_message, foo="bar", baz="quux"),
+                             err.as_dict())
+
+    def test_additional_info(self):
+        test_classes = [errors.ClientErrorUnprocessableEntity, errors.ClientErrorNotFound, errors.ClientErrorForbidden,
+                        errors.ClientErrorUnauthorized, errors.ClientErrorExternalServiceFailure,
+                        errors.ClientErrorTimedOut,
+                        errors.ServerError]
+        test_message = "Test additional info."
+        for cls in test_classes:
+            with self.subTest(cls):
+                err = cls(additional_info=test_message)
+                self.assertIn(test_message, err.error_message)

--- a/tests/machinery/test_errors.py
+++ b/tests/machinery/test_errors.py
@@ -76,6 +76,13 @@ class ErrorTestCast(django.test.TestCase):
                 err = cls(additional_info=test_message)
                 self.assertIn(test_message, err.error_message)
 
+    def test_clienterrorresponsewrapper(self):
+        message = "It's gone!"
+        response = http.HttpResponseGone(message)
+        err = errors.ClientErrorResponseWrapper(response)
+        self.assertEqual(response.status_code, err.error_code)
+        self.assertEqual(message, err.error_message)
+
     def test_clienterrorextrafields(self):
         err = errors.ClientErrorExtraFields(extra_fields=["foo", "bar", "baz"])
         self.assertIn("foo", err.error_message)

--- a/tests/machinery/test_errors.py
+++ b/tests/machinery/test_errors.py
@@ -61,7 +61,7 @@ class ErrorTestCast(django.test.TestCase):
         with self.assertRaises(AttributeError):
             err.error_code
 
-    def test_additional_info(self):
+    def test_additional_info_in_error(self):
         test_classes = [
             errors.ClientErrorUnprocessableEntity,
             errors.ClientErrorNotFound,
@@ -69,13 +69,21 @@ class ErrorTestCast(django.test.TestCase):
             errors.ClientErrorUnauthorized,
             errors.ClientErrorExternalServiceFailure,
             errors.ClientErrorTimedOut,
-            errors.ServerError,
         ]
         test_message = "Test additional info."
         for cls in test_classes:
             with self.subTest(cls):
                 err = cls(additional_info=test_message)
                 self.assertIn(test_message, err.error_message)
+
+    def test_servererror(self):
+        test_additional_info = "Test additional info."
+        with self.assertLogs(logger="django_declarative_apis.machinery.errors") as logs:
+            err = errors.ServerError(additional_info=test_additional_info)
+        self.assertIn("Server Error", err.error_message)
+        self.assertNotIn(test_additional_info, err.error_message)
+        self.assertIn("Server Error", logs.output[0])
+        self.assertIn(test_additional_info, logs.output[0])
 
     def test_clienterrorresponsewrapper(self):
         message = "It's gone!"

--- a/tests/machinery/test_errors.py
+++ b/tests/machinery/test_errors.py
@@ -1,0 +1,36 @@
+import django.test
+
+from django_declarative_apis.machinery import errors
+
+class ApiErrorTestCase(django.test.TestCase):
+
+    def test_tuple(self):
+        test_code, test_message = test_tuple = errors.HTTPS_REQUIRED
+        err = errors.ApiError(error_tuple=test_tuple)
+        self.assertEqual(err.error_code, test_code)
+        self.assertEqual(err.error_message, test_message)
+        self.assertDictEqual(err.as_dict(), dict(error_code=test_code, error_message=test_message))
+
+    def test_code_and_message(self):
+        test_code, test_message = 600, "test message"
+        err = errors.ApiError(code=test_code, message=test_message)
+        self.assertEqual(err.error_code, test_code)
+        self.assertEqual(err.error_message, test_message)
+        self.assertDictEqual(err.as_dict(), dict(error_code=test_code, error_message=test_message))
+
+    def test_bad_args(self):
+        try:
+            errors.ApiError()
+        except errors.ApiError:
+            errmsg = "ApiError requires arguments"
+            self.fail(errmsg)
+        except Exception:  # this is the expected result
+            pass
+        else:
+            self.fail("ApiError without arguments should raise an exception.")
+
+    def test_extra_args(self):
+        test_code, test_message = test_tuple = errors.AUTHORIZATION_FAILURE
+        err = errors.ApiError(error_tuple=test_tuple, foo="bar", baz="quux")
+        self.assertDictEqual(err.as_dict(),
+                             dict(error_code=test_code, error_message=test_message, foo="bar", baz="quux"))

--- a/tests/machinery/test_errors.py
+++ b/tests/machinery/test_errors.py
@@ -1,4 +1,5 @@
 import django.test
+from django import http
 
 from django_declarative_apis.machinery import errors
 
@@ -88,3 +89,17 @@ class ErrorTestCast(django.test.TestCase):
         self.assertIn("foo", err.error_message)
         self.assertIn("bar", err.error_message)
         self.assertIn("baz", err.error_message)
+
+    def test_clienterrorreadonlyfields(self):
+        err = errors.ClientErrorReadOnlyFields(read_only_fields=["foo", "bar", "baz"])
+        self.assertIn("foo", err.error_message)
+        self.assertIn("bar", err.error_message)
+        self.assertIn("baz", err.error_message)
+
+    def test_clienterrormissingfields(self):
+        extra_message = "Test extra message."
+        err = errors.ClientErrorMissingFields(missing_fields=["foo", "bar", "baz"], extra_message=extra_message)
+        self.assertIn("foo", err.error_message)
+        self.assertIn("bar", err.error_message)
+        self.assertIn("baz", err.error_message)
+        self.assertIn(extra_message, err.error_message)

--- a/tests/machinery/test_errors.py
+++ b/tests/machinery/test_errors.py
@@ -98,7 +98,9 @@ class ErrorTestCast(django.test.TestCase):
 
     def test_clienterrormissingfields(self):
         extra_message = "Test extra message."
-        err = errors.ClientErrorMissingFields(missing_fields=["foo", "bar", "baz"], extra_message=extra_message)
+        err = errors.ClientErrorMissingFields(
+            missing_fields=["foo", "bar", "baz"], extra_message=extra_message
+        )
         self.assertIn("foo", err.error_message)
         self.assertIn("bar", err.error_message)
         self.assertIn("baz", err.error_message)

--- a/tests/machinery/test_errors.py
+++ b/tests/machinery/test_errors.py
@@ -43,6 +43,23 @@ class ErrorTestCast(django.test.TestCase):
             err.as_dict(),
         )
 
+    def test_apierror_deprecated_error_code(self):
+        test_err = (999, "This is a fake error code.")
+        try:
+            errors.DEPRECATED_ERROR_CODES[test_err[0]] = test_err[1]
+            with self.assertRaises(ValueError):
+                with self.assertWarns(DeprecationWarning):
+                    errors.ApiError(error_tuple=test_err)
+        finally:
+            del errors.DEPRECATED_ERROR_CODES[test_err[0]]
+
+    def test_apierror_error_code_attributeerror(self):
+        test_error_tuple = (999, "This is a fake error code.")
+        err = errors.ApiError(error_tuple=test_error_tuple)
+        del err.__dict__["error_code"]
+        with self.assertRaises(AttributeError):
+            err.error_code
+
     def test_additional_info(self):
         test_classes = [
             errors.ClientErrorUnprocessableEntity,

--- a/tests/machinery/test_errors.py
+++ b/tests/machinery/test_errors.py
@@ -4,20 +4,23 @@ from django_declarative_apis.machinery import errors
 
 
 class ErrorTestCast(django.test.TestCase):
-
     def test_apierror_tuple(self):
         test_code, test_message = test_tuple = errors.HTTPS_REQUIRED
         err = errors.ApiError(error_tuple=test_tuple)
         self.assertEqual(test_code, err.error_code)
         self.assertEqual(test_message, err.error_message)
-        self.assertDictEqual(err.as_dict(), dict(error_code=test_code, error_message=test_message))
+        self.assertDictEqual(
+            err.as_dict(), dict(error_code=test_code, error_message=test_message)
+        )
 
     def test_apierror_code_and_message(self):
         test_code, test_message = 600, "test message"
         err = errors.ApiError(code=test_code, message=test_message)
         self.assertEqual(test_code, err.error_code)
         self.assertEqual(test_message, err.error_message)
-        self.assertDictEqual(dict(error_code=test_code, error_message=test_message), err.as_dict())
+        self.assertDictEqual(
+            dict(error_code=test_code, error_message=test_message), err.as_dict()
+        )
 
     def test_apierror_bad_args(self):
         try:
@@ -33,16 +36,31 @@ class ErrorTestCast(django.test.TestCase):
     def test_apierror_extra_args(self):
         test_code, test_message = test_tuple = errors.AUTHORIZATION_FAILURE
         err = errors.ApiError(error_tuple=test_tuple, foo="bar", baz="quux")
-        self.assertDictEqual(dict(error_code=test_code, error_message=test_message, foo="bar", baz="quux"),
-                             err.as_dict())
+        self.assertDictEqual(
+            dict(
+                error_code=test_code, error_message=test_message, foo="bar", baz="quux"
+            ),
+            err.as_dict(),
+        )
 
     def test_additional_info(self):
-        test_classes = [errors.ClientErrorUnprocessableEntity, errors.ClientErrorNotFound, errors.ClientErrorForbidden,
-                        errors.ClientErrorUnauthorized, errors.ClientErrorExternalServiceFailure,
-                        errors.ClientErrorTimedOut,
-                        errors.ServerError]
+        test_classes = [
+            errors.ClientErrorUnprocessableEntity,
+            errors.ClientErrorNotFound,
+            errors.ClientErrorForbidden,
+            errors.ClientErrorUnauthorized,
+            errors.ClientErrorExternalServiceFailure,
+            errors.ClientErrorTimedOut,
+            errors.ServerError,
+        ]
         test_message = "Test additional info."
         for cls in test_classes:
             with self.subTest(cls):
                 err = cls(additional_info=test_message)
                 self.assertIn(test_message, err.error_message)
+
+    def test_clienterrorextrafields(self):
+        err = errors.ClientErrorExtraFields(extra_fields=["foo", "bar", "baz"])
+        self.assertIn("foo", err.error_message)
+        self.assertIn("bar", err.error_message)
+        self.assertIn("baz", err.error_message)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -21,8 +21,6 @@ INSTALLED_APPS = ["django_declarative_apis", "django.contrib.contenttypes", "tes
 
 ROOT_URLCONF = "tests.urls"
 
-TEST_RUNNER = "tests.testutils.NoLoggingTestRunner"
-
 MIDDLEWARE = []
 
 REQUIRE_HTTPS_FOR_OAUTH = False


### PR DESCRIPTION
- Let ServerError take an `additional_info` argument
- Use f-strings throughout errors.py
- Use enum value rather than bare int for an error code
- Add some unit tests for errors.py to bump up coverage
- Bump coverage check to 91%
- Fix a Sphinx configuration error that appears with a new version of Sphinx (to get the PR checks to pass)

- [x] Update CHANGELOG.md
- [x] Update README.md (as needed)
- [x] New dependencies were added to `requirements.txt` or `requirements-dev.txt`
- [x] `pip install` succeeds with a clean virtualenv
- [x] There are new or modified tests that cover changes
- [x] Test coverage is maintained or expanded
