### PR TITLE
feat: Pydantic field validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [unreleased] - XXXX-XX-XX
 ### Added
 - [PR 100](https://github.com/salesforce/django-declarative-apis/pull/100) Improve `errors.py`
+- [PR 101](https://github.com/salesforce/django-declarative-apis/pull/101) Allow Pydantic models as field types
 
 # [0.23.1] - 2022-05-17
 ### Fixed

--- a/django_declarative_apis/machinery/attributes.py
+++ b/django_declarative_apis/machinery/attributes.py
@@ -113,7 +113,9 @@ class RequestProperty(EndpointAttribute):
 class TypedEndpointAttributeMixin:
     def __init__(self, *args, **kwargs):
         self.field_type = kwargs.pop("type", str)
-        if not any(issubclass(self.field_type, t) for t in RequestField.VALID_FIELD_TYPES):
+        if not any(
+            issubclass(self.field_type, t) for t in RequestField.VALID_FIELD_TYPES
+        ):
             raise NotImplementedError(
                 "Request fields of type {0} not supported".format(
                     self.field_type.__name__

--- a/django_declarative_apis/machinery/attributes.py
+++ b/django_declarative_apis/machinery/attributes.py
@@ -206,8 +206,8 @@ class RequestField(TypedEndpointAttributeMixin, RequestProperty):
     """Endpoint properties are called fields. Fields can be simple types such as int,
     or they can be used as a decorator on a function.
 
-    **Valid field types:** :code:`int`, :code:`bool`, :code:`float`, :code:`str`,
-    :code:`dict`, :code:`complex`
+    **Valid field types:** A subclass of :code:`int`, :code:`bool`, :code:`float`,
+    :code:`str`, :code:`dict`, :code:`complex`, :code:`pydantic.BaseModel`
 
     **Example**
 

--- a/django_declarative_apis/machinery/attributes.py
+++ b/django_declarative_apis/machinery/attributes.py
@@ -13,6 +13,7 @@ import string
 import time
 
 from django.db import models as django_models
+import pydantic
 
 from . import errors
 from . import tasks
@@ -112,7 +113,7 @@ class RequestProperty(EndpointAttribute):
 class TypedEndpointAttributeMixin:
     def __init__(self, *args, **kwargs):
         self.field_type = kwargs.pop("type", str)
-        if self.field_type not in RequestField.VALID_FIELD_TYPES:
+        if not any(issubclass(self.field_type, t) for t in RequestField.VALID_FIELD_TYPES):
             raise NotImplementedError(
                 "Request fields of type {0} not supported".format(
                     self.field_type.__name__
@@ -124,6 +125,8 @@ class TypedEndpointAttributeMixin:
         try:
             if self.field_type == bool and not isinstance(raw_value, self.field_type):
                 return "rue" in raw_value
+            elif issubclass(self.field_type, pydantic.BaseModel):
+                return self.field_type.parse_obj(raw_value)
             else:
                 if isinstance(raw_value, collections.abc.Iterable) and not isinstance(
                     raw_value, (str, dict)
@@ -258,7 +261,7 @@ class RequestField(TypedEndpointAttributeMixin, RequestProperty):
 
     """
 
-    VALID_FIELD_TYPES = (bool, int, float, complex, str, dict)
+    VALID_FIELD_TYPES = (bool, int, float, complex, str, dict, pydantic.BaseModel)
 
     def __init__(self, *args, **kwargs):
         self.default_value = kwargs.pop("default", None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ cryptography>=2.0,<=3.4.8
 decorator==4.0.11
 django-dirtyfields>=1.2.1
 oauthlib[signedtoken,rsa]>=2.0.6,<3.1.0
+pydantic>=1.8

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -96,8 +96,11 @@ class DeclarativeApisTestCase(TestCase):
             data = {"dict_type_field": dct}
             with self.subTest(message):
                 response = self.client.post(
-                    "/dictfield", consumer=self.consumer, data=data, expected_status_code=expected_status,
-                    content_type="application/json"
+                    "/dictfield",
+                    consumer=self.consumer,
+                    data=data,
+                    expected_status_code=expected_status,
+                    content_type="application/json",
                 )
                 if expected_status == HTTPStatus.OK:
                     self.assertDictEqual(json.loads(response.content), data)
@@ -112,17 +115,32 @@ class DeclarativeApisTestCase(TestCase):
         test_data = [
             (good_dict, HTTPStatus.OK, "no errors"),
             ({**good_dict, "length": "eleven"}, HTTPStatus.BAD_REQUEST, "bad length"),
-            ({**good_dict, "description": ['one', 'two']}, HTTPStatus.BAD_REQUEST, "bad description"),
-            ({**good_dict, "timestamp": "2022-10-24T99:99:99"}, HTTPStatus.BAD_REQUEST, "bad timestamp"),
-            ({**good_dict, "words": "foo bar baz quux"}, HTTPStatus.BAD_REQUEST, "bad words"),
+            (
+                {**good_dict, "description": ["one", "two"]},
+                HTTPStatus.BAD_REQUEST,
+                "bad description",
+            ),
+            (
+                {**good_dict, "timestamp": "2022-10-24T99:99:99"},
+                HTTPStatus.BAD_REQUEST,
+                "bad timestamp",
+            ),
+            (
+                {**good_dict, "words": "foo bar baz quux"},
+                HTTPStatus.BAD_REQUEST,
+                "bad words",
+            ),
         ]
 
         for dct, expected_status, message in test_data:
             data = {"pydantic_type_field": dct}
             with self.subTest(message):
                 response = self.client.post(
-                    "/pydanticfield", consumer=self.consumer, data=data, expected_status_code=expected_status,
-                    content_type="application/json"
+                    "/pydanticfield",
+                    consumer=self.consumer,
+                    data=data,
+                    expected_status_code=expected_status,
+                    content_type="application/json",
                 )
                 if expected_status == HTTPStatus.OK:
                     self.assertDictEqual(json.loads(response.content), data)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -76,3 +76,53 @@ class DeclarativeApisTestCase(TestCase):
             "/simple", consumer=self.consumer, expected_status_code=HTTPStatus.OK
         )
         self.assertTrue(cache.get("deferred_task_called"))
+
+    def test_dict_field_endpoint(self):
+        good_dict = {
+            "length": 11,
+            "description": "This is a description",
+            "timestamp": "2022-10-24T00:00:00",
+            "words": ["foo", "bar", "baz", "quux"],
+        }
+        test_data = [
+            (good_dict, HTTPStatus.OK, "good dict"),
+            ({}, HTTPStatus.OK, "empty_dict"),
+            (list(good_dict), HTTPStatus.BAD_REQUEST, "list"),
+            ("a string", HTTPStatus.BAD_REQUEST, "string"),
+            (1337, HTTPStatus.BAD_REQUEST, "int"),
+        ]
+
+        for dct, expected_status, message in test_data:
+            data = {"dict_type_field": dct}
+            with self.subTest(message):
+                response = self.client.post(
+                    "/dictfield", consumer=self.consumer, data=data, expected_status_code=expected_status,
+                    content_type="application/json"
+                )
+                if expected_status == HTTPStatus.OK:
+                    self.assertDictEqual(json.loads(response.content), data)
+
+    def test_pydantic_field_endpoint(self):
+        good_dict = {
+            "length": 11,
+            "description": "This is a description",
+            "timestamp": "2022-10-24T00:00:00",
+            "words": ["foo", "bar", "baz", "quux"],
+        }
+        test_data = [
+            (good_dict, HTTPStatus.OK, "no errors"),
+            ({**good_dict, "length": "eleven"}, HTTPStatus.BAD_REQUEST, "bad length"),
+            ({**good_dict, "description": ['one', 'two']}, HTTPStatus.BAD_REQUEST, "bad description"),
+            ({**good_dict, "timestamp": "2022-10-24T99:99:99"}, HTTPStatus.BAD_REQUEST, "bad timestamp"),
+            ({**good_dict, "words": "foo bar baz quux"}, HTTPStatus.BAD_REQUEST, "bad words"),
+        ]
+
+        for dct, expected_status, message in test_data:
+            data = {"pydantic_type_field": dct}
+            with self.subTest(message):
+                response = self.client.post(
+                    "/pydanticfield", consumer=self.consumer, data=data, expected_status_code=expected_status,
+                    content_type="application/json"
+                )
+                if expected_status == HTTPStatus.OK:
+                    self.assertDictEqual(json.loads(response.content), data)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -14,6 +14,8 @@ from django_declarative_apis.adapters import resource_adapter
 UUID4_REGEX = r"[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}"
 
 urlpatterns = [
-    re_path(r"^simple", resource_adapter(get=views.SimpleEndpointDefinition)),
-    re_path(r"^dict", resource_adapter(get=views.DictEndpointDefinition)),
+    re_path(r"^simple$", resource_adapter(get=views.SimpleEndpointDefinition)),
+    re_path(r"^dict$", resource_adapter(get=views.DictEndpointDefinition)),
+    re_path(r"^dictfield$", resource_adapter(post=views.DictFieldEndpointDefinition)),
+    re_path(r"^pydanticfield$", resource_adapter(post=views.PydanticFieldEndpointDefinition)),
 ]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -17,5 +17,7 @@ urlpatterns = [
     re_path(r"^simple$", resource_adapter(get=views.SimpleEndpointDefinition)),
     re_path(r"^dict$", resource_adapter(get=views.DictEndpointDefinition)),
     re_path(r"^dictfield$", resource_adapter(post=views.DictFieldEndpointDefinition)),
-    re_path(r"^pydanticfield$", resource_adapter(post=views.PydanticFieldEndpointDefinition)),
+    re_path(
+        r"^pydanticfield$", resource_adapter(post=views.PydanticFieldEndpointDefinition)
+    ),
 ]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -20,4 +20,8 @@ urlpatterns = [
     re_path(
         r"^pydanticfield$", resource_adapter(post=views.PydanticFieldEndpointDefinition)
     ),
+    re_path(
+        r"^nestedpydanticfield$",
+        resource_adapter(post=views.NestedPydanticFieldEndpointDefinition),
+    ),
 ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -82,3 +82,27 @@ class PydanticFieldEndpointDefinition(EndpointDefinition):
         return {
             "pydantic_type_field": json.loads(self.pydantic_type_field.json()),
         }
+
+
+class _ModelA(pydantic.BaseModel):
+    a: str
+
+
+class _ModelB(pydantic.BaseModel):
+    b: str
+    c: _ModelA
+
+
+class NestedPydanticFieldEndpointDefinition(EndpointDefinition):
+    def is_authorized(self):
+        return True
+
+    nested_pydantic_type_field = field(type=_ModelB, required=True)
+
+    @endpoint_resource(type=dict)
+    def resource(self):
+        return {
+            "nested_pydantic_type_field": json.loads(
+                self.nested_pydantic_type_field.json()
+            ),
+        }

--- a/tests/views.py
+++ b/tests/views.py
@@ -5,14 +5,20 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 
+import datetime
+import json
+from typing import List
+
+from django.core.cache import cache
+
+import pydantic
+
 from django_declarative_apis.machinery import (
     EndpointDefinition,
     field,
     deferrable_task,
     endpoint_resource,
 )
-from django.core.cache import cache
-
 from tests.models import TestModel
 
 
@@ -44,3 +50,35 @@ class DictEndpointDefinition(EndpointDefinition):
     def resource(self):
         inst = TestModel.objects.create(int_field=1)
         return {"test": inst, "deep_test": {"test": inst}}
+
+
+class DictFieldEndpointDefinition(EndpointDefinition):
+    def is_authorized(self):
+        return True
+
+    dict_type_field = field(type=dict, required=True)
+
+    @endpoint_resource(type=dict)
+    def resource(self):
+        return {
+            "dict_type_field": self.dict_type_field,
+        }
+
+
+class PydanticFieldEndpointDefinition(EndpointDefinition):
+    def is_authorized(self):
+        return True
+
+    class _TestData(pydantic.BaseModel):
+        length: int
+        description: str
+        timestamp: datetime.datetime
+        words: List[str]
+
+    pydantic_type_field = field(type=_TestData, required=True)
+
+    @endpoint_resource(type=dict)
+    def resource(self):
+        return {
+            "pydantic_type_field": json.loads(self.pydantic_type_field.json()),
+        }


### PR DESCRIPTION
Allow supplying a Pydantic model as a field `type` for validation and coercion.

A big win: we can use a Pydantic model to validate the contents of a dict field value (not just that the value is a dict!)

- [x] Update CHANGELOG.md
- [x] Update README.md (as needed)
- [x] New dependencies were added to `requirements.txt` or `requirements-dev.txt`
- [x] `pip install` succeeds with a clean virtualenv
- [x] There are new or modified tests that cover changes
- [x] Test coverage is maintained or expanded
