### PR TITLE
Split the last release's Changelog into sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [0.24.0] - 2022-11-03
 ### Added
+- [PR 101](https://github.com/salesforce/django-declarative-apis/pull/101) Allow Pydantic models as field types
+
+### Fixed
 - [PR 103](https://github.com/salesforce/django-declarative-apis/pull/103) Update contributing doc
 - [PR 102](https://github.com/salesforce/django-declarative-apis/pull/102) Fix typos in docs and tests
-- [PR 101](https://github.com/salesforce/django-declarative-apis/pull/101) Allow Pydantic models as field types
+
+### Changed
 - [PR 100](https://github.com/salesforce/django-declarative-apis/pull/100) Improve `errors.py`
 
 # [0.23.1] - 2022-05-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [unreleased] - XXXX-XX-XX
+### Fixed
+- [PR 105](https://github.com/salesforce/django-declarative-apis/pull/105) Split the last release's Changelog into sections
+
 # [0.24.0] - 2022-11-03
 ### Added
 - [PR 101](https://github.com/salesforce/django-declarative-apis/pull/101) Allow Pydantic models as field types


### PR DESCRIPTION
I didn't appropriately add "Added", "Changed", "Fixed" sections to the last release's Changelog.  This PR fixes that.

- [x] Update CHANGELOG.md
- [x] Update README.md (as needed)
- [x] New dependencies were added to `requirements.txt` or `requirements-dev.txt`
- [x] `pip install` succeeds with a clean virtualenv
- [x] There are new or modified tests that cover changes
- [x] Test coverage is maintained or expanded
