### PR TITLE
Try the old way of specifying the Python version

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,10 +1,7 @@
 version: 2
 
-build:
-  tools:
-    python: "3.9"
-
 python:
+  version: "3.9"
   install:
     - method: pip
       path: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [unreleased] - XXXX-XX-XX
 ### Added
 - [PR 106](https://github.com/salesforce/django-declarative-apis/pull/106) Test against Python 3.11 in PR checks
-- [PR 107](https://github.com/salesforce/django-declarative-apis/pull/107) Update to use pyproject.toml
+
+### Fixed
+- [PR 110](https://github.com/salesforce/django-declarative-apis/pull/110) Fix ReadTheDocs build by specifying python version differently
 - [PR 108](https://github.com/salesforce/django-declarative-apis/pull/107) Fix ReadTheDocs documentation build with pyproject.toml
+
+### Changed
 - [PR 109](https://github.com/salesforce/django-declarative-apis/pull/109) Update Github actions
+- [PR 107](https://github.com/salesforce/django-declarative-apis/pull/107) Update to use pyproject.toml
 
 # [0.24.0] - 2022-11-03
 ### Added


### PR DESCRIPTION
The ReadTheDocs build is failing based on me using `build.tools.python`:

https://readthedocs.org/projects/django-declarative-apis/builds/18794071/

The documentation led me to believe this was the right way to specify the Python version.  But, I'll try the old way.

https://docs.readthedocs.io/en/stable/config-file/v2.html#python-version

- [x] Update CHANGELOG.md
- [x] Update README.md (as needed)
- [x] New dependencies were added to `pyproject.toml`
- [x] `pip install` succeeds with a clean virtualenv
- [x] There are new or modified tests that cover changes
- [x] Test coverage is maintained or expanded
