### PR TITLE
chore(deps): Update oauthlib to >=3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [PR 109](https://github.com/salesforce/django-declarative-apis/pull/109) Update Github actions
 - [PR 107](https://github.com/salesforce/django-declarative-apis/pull/107) Update to use pyproject.toml
+- [PR XXX](https://github.com/salesforce/django-declarative-apis/pull/107) Require oauthlib >= 3.1.0
 
 # [0.24.0] - 2022-11-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR 112](https://github.com/salesforce/django-declarative-apis/pull/112) Try again to use new ReadTheDocs config
 - [PR 111](https://github.com/salesforce/django-declarative-apis/pull/111) ReadTheDocs only supports up to Python 3.8
 - [PR 110](https://github.com/salesforce/django-declarative-apis/pull/110) Fix ReadTheDocs build by specifying python version differently
-- [PR 108](https://github.com/salesforce/django-declarative-apis/pull/107) Fix ReadTheDocs documentation build with pyproject.toml
+- [PR 108](https://github.com/salesforce/django-declarative-apis/pull/108) Fix ReadTheDocs documentation build with pyproject.toml
 
 ### Changed
+- [PR 113](https://github.com/salesforce/django-declarative-apis/pull/113) Require oauthlib >= 3.1.0
 - [PR 109](https://github.com/salesforce/django-declarative-apis/pull/109) Update Github actions
 - [PR 107](https://github.com/salesforce/django-declarative-apis/pull/107) Update to use pyproject.toml
-- [PR XXX](https://github.com/salesforce/django-declarative-apis/pull/107) Require oauthlib >= 3.1.0
 
 # [0.24.0] - 2022-11-03
 ### Added

--- a/django_declarative_apis/authentication/oauthlib/endpoint.py
+++ b/django_declarative_apis/authentication/oauthlib/endpoint.py
@@ -85,8 +85,8 @@ class TweakedSignatureOnlyEndpoint(SignatureOnlyEndpoint):
 
         if valid_client and not valid_signature:  # TOOPHER
             norm_params = signature.normalize_parameters(request.params)  # TOOPHER
-            uri = signature.normalize_base_string_uri(request.uri)  # TOOPHER
-            base_signing_string = signature.construct_base_string(
+            uri = signature.base_string_uri(request.uri)  # TOOPHER
+            base_signing_string = signature.signature_base_string(
                 request.http_method, uri, norm_params
             )  # TOOPHER
             self.validation_error_message = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "cryptography>=2.0,<=3.4.8",
   "decorator==4.0.11",
   "django-dirtyfields>=1.2.1",
-  "oauthlib[signedtoken,rsa]>=2.0.6,<3.1.0",
+  "oauthlib[signedtoken,rsa]>=3.1.0",
   "pydantic>=1.8"
 ]
 keywords = [


### PR DESCRIPTION
A couple of methods were renamed in `oauthlib` 3.1.0:

- [Renamed `construct_base_string` to `signature_base_string`](https://github.com/oauthlib/oauthlib/commit/42023d8303113073e31a57e1bbf70216b7120e20)
- [Renamed `normalize_base_string_uri` to `base-string_uri`](https://github.com/oauthlib/oauthlib/commit/0ef0a9c4342dfee4bd3aef7d6d9fa09e7226a732#)

- [x] Update CHANGELOG.md
- [x] Update README.md (as needed)
- [x] New dependencies were added to `pyproject.toml`
- [x] `pip install` succeeds with a clean virtualenv
- [x] There are new or modified tests that cover changes
- [x] Test coverage is maintained or expanded
