### PR TITLE
chore: Only run PR checks on `pull_request`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: unit-tests-and-static-analysis
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [unreleased] - XXXX-XX-XX
+### Changed
+- [PR XXX](https://github.com/salesforce/django-declarative-apis/pull/XXX) Only run PR checks on `pull_request`
+
 # [0.25.0] - 2022-12-19
 ### Added
 - [PR 106](https://github.com/salesforce/django-declarative-apis/pull/106) Test against Python 3.11 in PR checks


### PR DESCRIPTION
- Only test on pull_request
- Update CHANGELOG

- [x] Update CHANGELOG.md
- [x] Update README.md (as needed)
- [x] New dependencies were added to `pyproject.toml`
- [x] `pip install` succeeds with a clean virtualenv
- [x] There are new or modified tests that cover changes
- [x] Test coverage is maintained or expanded
