### PR TITLE
fix: Handle malformed auth header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [unreleased] - XXXX-XX-XX
+- [PR 122](https://github.com/salesforce/django-declarative-apis/pull/122) Handle malformed OAuth header
+
 # [0.25.2] - 2023-01-24
 ### Fixed
 - [PR 118](https://github.com/salesforce/django-declarative-apis/pull/118) Fix typo in docs

--- a/django_declarative_apis/authentication/oauthlib/oauth1.py
+++ b/django_declarative_apis/authentication/oauthlib/oauth1.py
@@ -60,6 +60,12 @@ class TwoLeggedOauth1(Authenticator):
             missing = list(
                 param for param in params if param not in collected_request_parameters
             )
+        except ValueError as e:
+            error_message = str(e)
+            logger.error(error_message)
+            oauth_error = oauth_errors.build_error(error_message)
+            request.auth_header = getattr(oauth_error, "auth_header", None)
+            return oauth_error
         except Exception:  # pragma: nocover
             missing = params
 

--- a/django_declarative_apis/authentication/oauthlib/oauth1.py
+++ b/django_declarative_apis/authentication/oauthlib/oauth1.py
@@ -48,15 +48,15 @@ class TwoLeggedOauth1(Authenticator):
 
         params.extend(parameters)
 
-        collected_request_parameters = dict(
-            signature.collect_parameters(
-                uri_query=request.GET.urlencode(),
-                body=request.POST.dict(),
-                headers=request.META,
-                exclude_oauth_signature=False,
-            )
-        )
         try:
+            collected_request_parameters = dict(
+                signature.collect_parameters(
+                    uri_query=request.GET.urlencode(),
+                    body=request.POST.dict(),
+                    headers=request.META,
+                    exclude_oauth_signature=False,
+                )
+            )
             missing = list(
                 param for param in params if param not in collected_request_parameters
             )

--- a/django_declarative_apis/authentication/oauthlib/oauth_errors.py
+++ b/django_declarative_apis/authentication/oauthlib/oauth_errors.py
@@ -49,6 +49,12 @@ class OAuthInvalidVersionError(OAuthError):
         self.auth_header = 'OAuth realm="API",oauth_problem=version_rejected&oauth_acceptable_versions=1.0-1.0'
 
 
+class OAuthParameterRejectedError(OAuthError):
+    def __init__(self, detail):
+        self.detail = "{0}.".format(detail)
+        self.auth_header = 'OAuth realm="API",oauth_problem=parameters_rejected'
+
+
 """
 Map internal OAuth errors to those specified in the OAuth Problem Reporting proposal
 http://wiki.oauth.net/w/page/12238543/ProblemReporting
@@ -62,6 +68,8 @@ error_to_human_readable_message = {
 
 
 def build_error(error_message):
+    if "Malformed authorization header" in error_message:
+        return OAuthParameterRejectedError(error_message)
     if ("Timestamp given is invalid" in error_message) or (
         "Invalid timestamp" in error_message
     ):

--- a/django_declarative_apis/resources/resource.py
+++ b/django_declarative_apis/resources/resource.py
@@ -117,7 +117,7 @@ class Resource:
 
     def determine_emitter(self, request, *args, **kwargs):
         """
-        Function for determening which emitter to use
+        Function for determining which emitter to use
         for output. It lives here so you can easily subclass
         `Resource` in order to change how emission is detected.
 

--- a/tests/authentication/oauthlib/test_oauth1.py
+++ b/tests/authentication/oauthlib/test_oauth1.py
@@ -19,7 +19,7 @@ from django_declarative_apis.authentication.oauthlib import oauth1, oauth_errors
 from tests import testutils
 
 
-class TwoLeggedOauth1TestCase(unittest.TestCase):
+class TwoLeggedOauth1TestCase(django.test.TestCase):
     def setUp(self):
         self.request_factory = django.test.RequestFactory()
         self.consumer = models.OauthConsumer.objects.create(name="test")
@@ -35,6 +35,18 @@ class TwoLeggedOauth1TestCase(unittest.TestCase):
             "oauth_signature,oauth_signature_method,oauth_timestamp",
         )
 
+    def test_is_authenticated_malformed_auth_header(self):
+        request = self.request_factory.get("/")
+        request.META["Authorization"] = "Wrong"
+        testutils.OAuthClientHandler._build_request(request)
+
+        authenticator = oauth1.TwoLeggedOauth1()
+        result = authenticator.is_authenticated(request)
+        self.assertIsInstance(result, oauth_errors.OAuthMissingParameterError)
+        self.assertEqual(
+            result.detail,
+            "Parameters missing: oauth_consumer_key,oauth_nonce,oauth_signature,oauth_signature_method,oauth_timestamp",
+        )
     def test_is_authenticated_django_header_sillyness_and_auth_failure(self):
         request = self.request_factory.get("/")
         request.META["HTTP_AUTHORIZATION"] = "OAuth foo=bar"

--- a/tests/authentication/oauthlib/test_oauth1.py
+++ b/tests/authentication/oauthlib/test_oauth1.py
@@ -7,7 +7,6 @@
 
 import http
 import json
-import unittest
 
 import django.test
 import django.http
@@ -47,6 +46,7 @@ class TwoLeggedOauth1TestCase(django.test.TestCase):
             result.detail,
             "Parameters missing: oauth_consumer_key,oauth_nonce,oauth_signature,oauth_signature_method,oauth_timestamp",
         )
+
     def test_is_authenticated_django_header_sillyness_and_auth_failure(self):
         request = self.request_factory.get("/")
         request.META["HTTP_AUTHORIZATION"] = "OAuth foo=bar"

--- a/tests/authentication/oauthlib/test_oauth1.py
+++ b/tests/authentication/oauthlib/test_oauth1.py
@@ -41,10 +41,14 @@ class TwoLeggedOauth1TestCase(django.test.TestCase):
 
         authenticator = oauth1.TwoLeggedOauth1()
         result = authenticator.is_authenticated(request)
-        self.assertIsInstance(result, oauth_errors.OAuthMissingParameterError)
+        self.assertIsInstance(result, oauth_errors.OAuthError)
         self.assertEqual(
             result.detail,
-            "Parameters missing: oauth_consumer_key,oauth_nonce,oauth_signature,oauth_signature_method,oauth_timestamp",
+            "Malformed authorization header.",
+        )
+        self.assertEqual(
+            request.auth_header,
+            'OAuth realm="API",oauth_problem=parameters_rejected',
         )
 
     def test_is_authenticated_django_header_sillyness_and_auth_failure(self):


### PR DESCRIPTION
- Handle "Malformed authorization header" `ValueError` that bubbles up from `oauthlib` the same way we handle other oauth errors
- Fix a docstring typo

- [x] Update CHANGELOG.md
- [x] Update README.md (as needed)
- [x] New dependencies were added to `pyproject.toml`
- [x] `pip install` succeeds with a clean virtualenv
- [x] There are new or modified tests that cover changes
- [x] Test coverage is maintained or expanded
