### PR TITLE
Docs: add comment explaining why `dicts` are excluded from filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [unreleased]
 - [PR 138](https://github.com/salesforce/django-declarative-apis/pull/138) Docs: Correct imports in code-blocks
 - [PR 139](https://github.com/salesforce/django-declarative-apis/pull/139) Docs: Correct documentation for default value of `required` on `field`
+- [PR 140](https://github.com/salesforce/django-declarative-apis/pull/140) Docs: Add comment explaining why `dict`s don't have filters applied
 
 # [0.31.4] - 2023-10-12
 - [PR 137](https://github.com/salesforce/django-declarative-apis/pull/137) Finalize endpoints before dispatching async tasks

--- a/django_declarative_apis/machinery/filtering.py
+++ b/django_declarative_apis/machinery/filtering.py
@@ -171,6 +171,7 @@ def _get_filtered_field_value(  # noqa: C901
         val = val.all()
 
     # should this value be passed through the filters itself?
+    # `dict` is intentionally excluded to allow endpoints to return an arbitrary response that bypasses filtering
     if val.__class__ in filter_def or isinstance(
         val, (list, tuple, models.Model, models.query.QuerySet, pydantic.BaseModel)
     ):


### PR DESCRIPTION
- [x] Update CHANGELOG.md
- [x] Update README.md (as needed)
- [x] New dependencies were added to `pyproject.toml`
- [x] `pip install` succeeds with a clean virtualenv
- [x] There are new or modified tests that cover changes
- [x] Test coverage is maintained or expanded
