### PR TITLE
Testing: drop Python 3.7, add Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Matching the Python support schedule:  https://devguide.python.org/versions/

- [ ] Update CHANGELOG.md
- [ ] Update README.md (as needed)
- [ ] New dependencies were added to `pyproject.toml`
- [ ] `pip install` succeeds with a clean virtualenv
- [ ] There are new or modified tests that cover changes
- [ ] Test coverage is maintained or expanded
