### PR TITLE
Fix broken link in emitters.py

### DIFF
--- a/django_declarative_apis/resources/emitters.py
+++ b/django_declarative_apis/resources/emitters.py
@@ -233,7 +233,7 @@ WARNING: Accepting arbitrary pickled data is a huge security concern.
 The unpickler has been disabled by default now, and if you want to use
 it, please be aware of what implications it will have.
 
-Read more: http://nadiana.com/python-pickle-insecure
+Read more: https://web.archive.org/web/20130423223601/http://nadiana.com/python-pickle-insecure
 
 Uncomment the line below to enable it. You're doing so at your own risk.
 """


### PR DESCRIPTION
There is a broken link in this project to a blog that does not exist anymore. I replaced it with the internet archive.

http://nadiana.com/python-pickle-insecure --> https://web.archive.org/web/20130423223601/http://nadiana.com/python-pickle-insecure

I found this links using a tool I created called [link-inspector](https://github.com/justindhillon/link-inspector) .  If you find this PR useful, give the repo a :star: 