### PR TITLE
Custom Event Hooks Event Emission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ ENV/
 # IntelliJ
 /out/
 
+# Visual Studio Code
+.vscode/
+
 # mpeltonen/sbt-idea plugin
 .idea_modules/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [Unreleased]
 - [PR 156](https://github.com/salesforce/django-declarative-apis/pull/156) Update GitHub action versions
 - [PR 162](https://github.com/salesforce/django-declarative-apis/pull/162) Fix Makefile install target
+- [PR 164](https://github.com/salesforce/django-declarative-apis/pull/164) Custom Event Hooks for Non-NewRelic Event Emission
 
 # [0.31.7]
 - [PR 148](https://github.com/salesforce/django-declarative-apis/pull/148) chore: upgrade django 4.2 LTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [Unreleased]
 - [PR 156](https://github.com/salesforce/django-declarative-apis/pull/156) Update GitHub action versions
 - [PR 162](https://github.com/salesforce/django-declarative-apis/pull/162) Fix Makefile install target
-- [PR 164](https://github.com/salesforce/django-declarative-apis/pull/164) Custom Event Hooks for Non-NewRelic Event Emission
+- [PR 164](https://github.com/salesforce/django-declarative-apis/pull/164) Custom Event Hooks Event Emission
 
 # [0.31.7]
 - [PR 148](https://github.com/salesforce/django-declarative-apis/pull/148) chore: upgrade django 4.2 LTS

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ class PingDefinition(machinery.BaseEndpointDefinition):
         return {'ping': 'pong'}
 ```
 
-Optional: Implement Custom Event Hooks for Non-NewRelic Event Emission
+Optional: Implement Custom Event Hooks for Event Emission
 -----
 ```bash
 # settings.py 

--- a/README.md
+++ b/README.md
@@ -95,3 +95,10 @@ class PingDefinition(machinery.BaseEndpointDefinition):
     def resource(self):
         return {'ping': 'pong'}
 ```
+
+Optional: Implement Custom Event Hooks for Non-NewRelic Event Emission
+-----
+```bash
+# settings.py 
+DDA_EVENT_HOOK = "my_app.hooks.custom_event_handler"
+```

--- a/django_declarative_apis/events.py
+++ b/django_declarative_apis/events.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, salesforce.com, inc.
+# Copyright (c) 2025, salesforce.com, inc.
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -75,10 +75,6 @@ def emit_events(event_type, payload):
             logger.info(f"Event emitted via custom hook: {event_type}")
         except Exception as e:
             logger.error(f"Error in custom hook for events: {e}", exc_info=True)
-    else:
-        logger.info(
-            f"No custom hook configured. Skipping custom hook for event: {event_type}"
-        )
 
     if newrelic_agent:
         try:
@@ -86,10 +82,3 @@ def emit_events(event_type, payload):
             logger.info(f"Event emitted to New Relic: {event_type}")
         except Exception as e:
             logger.error(f"Error sending event to New Relic: {e}", exc_info=True)
-    else:
-        logger.info(f"No New Relic agent configured. Event {event_type} not sent.")
-
-    if not hook and not newrelic_agent:
-        logger.warning(
-            f"No event emitter configured for event: {event_type}. Event not sent."
-        )

--- a/django_declarative_apis/events.py
+++ b/django_declarative_apis/events.py
@@ -5,80 +5,64 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 
+import importlib
 from enum import Enum
 import logging
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
-try:
-    from newrelic import agent as newrelic_agent
-except ImportError:
-    newrelic_agent = None
-
+HOOK = getattr(settings, "DDA_EVENT_HOOK", None)
 
 # Enum for event types
 class EventType(Enum):
-    QUEUE_LENGTH = "task_runner:queue_length"
-    TASK_RETRY = "task_runner:retry"
+    QUEUE_SNAPSHOT = "queue_snapshot"
+    TASK_RETRY_ATTEMPT = "task_retry"
 
 
 def _import_hook(hook_path):
     """
-    Import a hook function from a string path.
+    Import and return a hook function from a string path.
+
+    This function dynamically imports a hook function specified by a dotted string path.
+    It ensures that the imported object is callable and raises an error if it is not.
 
     Args:
-        hook_path (str): The dotted path to the hook function.
+        hook_path (str): The dotted string path to the hook function. 
+                         For example, 'module.submodule.function'.
 
     Returns:
-        Callable: The hook function.
+        Callable: The imported hook function.
 
     Raises:
-        ValueError: If the hook path is invalid.
-        ImportError: If the module or function cannot be imported.
+        TypeError: If the imported object is not callable.
     """
-    module_name = None
-    func_name = None
-
-    try:
-        module_name, func_name = hook_path.rsplit(".", 1)
-    except ValueError:
-        raise ValueError(
-            f"Invalid hook path: '{hook_path}'. Must be in the format 'module_name.function_name'."
-        )
-
-    try:
-        module = __import__(module_name, fromlist=[func_name])
-        return getattr(module, func_name)
-    except ImportError as e:
-        raise ImportError(f"Could not import module '{module_name}': {e}") from e
-    except AttributeError as e:
-        raise ImportError(
-            f"Module '{module_name}' does not have an attribute '{func_name}': {e}"
-        ) from e
+    module_path, function_name = hook_path.rsplit(".", 1)
+    module = importlib.import_module(module_path)
+    function = getattr(module, function_name)
+    if not callable(function):
+        raise TypeError(f"Consumer getter ({hook_path}) must be callable")
+    return function
 
 
 def emit_events(event_type, payload):
     """
-    Emit a metric event using the configured hook and New Relic if configured.
+    Emit a metric event using the configured hook.
+    This function sends an event to a custom hook, if configured, with the specified
+    event type and payload. The hook is dynamically imported and executed. Logs any errors
+    encountered during the hook execution.
 
     Args:
-        metric_type (str): Type of the metric (from MetricType enum).
-        payload (dict): The data associated with the metric.
+        event_type (EventType): The type of the event, as defined in the EventType enum.
+        payload (dict): A dictionary containing the data associated with the event.
+                        This data is passed to the custom hook for processing.
+    Raises:
+        Exception: Logs an error if the custom hook encounters an issue during execution.
     """
-    hook = getattr(settings, "DDA_EVENT_HOOK", None)
-
-    if hook:
+    if HOOK:
         try:
-            hook_callable = _import_hook(hook)
+            hook_callable = _import_hook(HOOK)
             hook_callable(event_type, payload)
             logger.info(f"Event emitted via custom hook: {event_type}")
         except Exception as e:
             logger.error(f"Error in custom hook for events: {e}", exc_info=True)
-
-    if newrelic_agent:
-        try:
-            newrelic_agent.record_custom_event(event_type, payload)
-            logger.info(f"Event emitted to New Relic: {event_type}")
-        except Exception as e:
-            logger.error(f"Error sending event to New Relic: {e}", exc_info=True)

--- a/django_declarative_apis/events.py
+++ b/django_declarative_apis/events.py
@@ -1,0 +1,71 @@
+#
+# Copyright (c) 2019, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+#
+
+from enum import Enum
+import logging
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+try:
+    from newrelic import agent as newrelic_agent
+except ImportError:
+    newrelic_agent = None
+
+
+# Enum for event types
+class EventType(Enum):
+    QUEUE_LENGTH = "task_runner:queue_length"
+    TASK_RETRY = "task_runner:retry"
+
+
+def _import_hook(hook_path):
+    """
+    Import a hook function from a string path.
+
+    Args:
+        hook_path (str): The dotted path to the hook function.
+
+    Returns:
+        Callable: The hook function.
+    """
+    module_name, func_name = hook_path.rsplit(".", 1)
+    module = __import__(module_name, fromlist=[func_name])
+    return getattr(module, func_name)
+
+
+def emit_events(metric_type, payload):
+    """
+    Emit a metric event using the configured hook or default to New Relic.
+
+    Args:
+        metric_type (str): Type of the metric (from MetricType enum).
+        payload (dict): The data associated with the metric.
+    """
+    # Check if a custom hook is configured
+    hook = getattr(settings, "DDA_METRIC_HOOK", None)
+
+    if hook:
+        try:
+            # Dynamically load and call the hook
+            hook_callable = _import_hook(hook)
+            hook_callable(metric_type, payload)
+            logger.info(f"Metric emitted via custom hook: {metric_type}")
+        except Exception as e:
+            logger.error(f"Error in custom hook for metrics: {e}", exc_info=True)
+    else:
+        # Fallback to New Relic if no hook is configured
+        if newrelic_agent:
+            try:
+                newrelic_agent.record_custom_event(metric_type, payload)
+                logger.info(f"Metric emitted to New Relic: {metric_type}")
+            except Exception as e:
+                logger.error(f"Error sending metric to New Relic: {e}", exc_info=True)
+        else:
+            logger.warning(
+                "No metrics hook or New Relic agent configured. Metric not sent."
+            )

--- a/django_declarative_apis/events.py
+++ b/django_declarative_apis/events.py
@@ -75,7 +75,11 @@ def emit_events(event_type, payload):
             logger.info(f"Event emitted via custom hook: {event_type}")
         except Exception as e:
             logger.error(f"Error in custom hook for events: {e}", exc_info=True)
-    
+    else:
+        logger.info(
+            f"No custom hook configured. Skipping custom hook for event: {event_type}"
+        )
+
     if newrelic_agent:
         try:
             newrelic_agent.record_custom_event(event_type, payload)
@@ -83,6 +87,9 @@ def emit_events(event_type, payload):
         except Exception as e:
             logger.error(f"Error sending event to New Relic: {e}", exc_info=True)
     else:
+        logger.info(f"No New Relic agent configured. Event {event_type} not sent.")
+
+    if not hook and not newrelic_agent:
         logger.warning(
-            "No New Relic agent configured. Event not sent."
+            f"No event emitter configured for event: {event_type}. Event not sent."
         )

--- a/django_declarative_apis/events.py
+++ b/django_declarative_apis/events.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 HOOK = getattr(settings, "DDA_EVENT_HOOK", None)
 
+
 # Enum for event types
 class EventType(Enum):
     QUEUE_SNAPSHOT = "queue_snapshot"
@@ -28,7 +29,7 @@ def _import_hook(hook_path):
     It ensures that the imported object is callable and raises an error if it is not.
 
     Args:
-        hook_path (str): The dotted string path to the hook function. 
+        hook_path (str): The dotted string path to the hook function.
                          For example, 'module.submodule.function'.
 
     Returns:

--- a/django_declarative_apis/events.py
+++ b/django_declarative_apis/events.py
@@ -60,7 +60,7 @@ def _import_hook(hook_path):
 
 def emit_events(event_type, payload):
     """
-    Emit a metric event using the configured hook or default to New Relic.
+    Emit a metric event using the configured hook and New Relic if configured.
 
     Args:
         metric_type (str): Type of the metric (from MetricType enum).
@@ -75,14 +75,14 @@ def emit_events(event_type, payload):
             logger.info(f"Event emitted via custom hook: {event_type}")
         except Exception as e:
             logger.error(f"Error in custom hook for events: {e}", exc_info=True)
+    
+    if newrelic_agent:
+        try:
+            newrelic_agent.record_custom_event(event_type, payload)
+            logger.info(f"Event emitted to New Relic: {event_type}")
+        except Exception as e:
+            logger.error(f"Error sending event to New Relic: {e}", exc_info=True)
     else:
-        if newrelic_agent:
-            try:
-                newrelic_agent.record_custom_event(event_type, payload)
-                logger.info(f"Event emitted to New Relic: {event_type}")
-            except Exception as e:
-                logger.error(f"Error sending event to New Relic: {e}", exc_info=True)
-        else:
-            logger.warning(
-                "No events hook or New Relic agent configured. Event not sent."
-            )
+        logger.warning(
+            "No New Relic agent configured. Event not sent."
+        )

--- a/django_declarative_apis/machinery/tasks.py
+++ b/django_declarative_apis/machinery/tasks.py
@@ -70,7 +70,7 @@ def _log_task_stats(
         cache.set(QUEUE_LENGTH_CACHE_KEY, queue_length)
 
         emit_events(
-            EventType.QUEUE_LENGTH.value,
+            EventType.QUEUE_SNAPSHOT,
             {
                 "queue_length": queue_length,
                 "queue": queue,
@@ -106,7 +106,7 @@ def _log_task_stats(
 
 def _log_retry_stats(method_name, resource_instance_id, correlation_id):
     emit_events(
-        EventType.TASK_RETRY.value,
+        EventType.TASK_RETRY_ATTEMPT,
         {"method_name": method_name, "resource_instance_id": resource_instance_id},
     )
     logger.warning(

--- a/django_declarative_apis/machinery/tasks.py
+++ b/django_declarative_apis/machinery/tasks.py
@@ -16,11 +16,7 @@ import kombu.exceptions
 from django.conf import settings
 from django.core.cache import cache
 import django.db.models
-
-try:
-    from newrelic import agent as newrelic_agent
-except ImportError:
-    newrelic_agent = None
+from django_declarative_apis.events import emit_events, EventType
 
 try:
     import cid.locals
@@ -73,19 +69,18 @@ def _log_task_stats(
 
         cache.set(QUEUE_LENGTH_CACHE_KEY, queue_length)
 
-        if newrelic_agent:
-            newrelic_agent.record_custom_event(
-                "task_runner:queue_length",
-                {
-                    "queue_length": queue_length,
-                    "queue": queue,
-                    "routing_key": routing_key,
-                    "wait_time_seconds": wait_time,
-                    "queue_delay_seconds": queue_delay,
-                    "process_task_count": process_task_count,
-                    "correlation_id": correlation_id,
-                },
-            )
+        emit_events(
+            EventType.QUEUE_LENGTH.value,
+            {
+                "queue_length": queue_length,
+                "queue": queue,
+                "routing_key": routing_key,
+                "wait_time_seconds": wait_time,
+                "queue_delay_seconds": queue_delay,
+                "process_task_count": process_task_count,
+                "correlation_id": correlation_id,
+            },
+        )
 
         logger.info(
             "method=%s, resource_id=%s, queue_length=%s, queue=%s, routing_key=%s, task_wait_time=%s, "
@@ -110,17 +105,16 @@ def _log_task_stats(
 
 
 def _log_retry_stats(method_name, resource_instance_id, correlation_id):
-    if newrelic_agent:
-        newrelic_agent.record_custom_event(
-            "task_runner:retry",
-            {"method_name": method_name, "resource_instance_id": resource_instance_id},
-        )
-        logger.warning(
-            "will retry task: method=%s, resource_id=%s, correlation_id=%s",
-            method_name,
-            resource_instance_id,
-            correlation_id,
-        )
+    emit_events(
+        EventType.TASK_RETRY.value,
+        {"method_name": method_name, "resource_instance_id": resource_instance_id},
+    )
+    logger.warning(
+        "will retry task: method=%s, resource_id=%s, correlation_id=%s",
+        method_name,
+        resource_instance_id,
+        correlation_id,
+    )
 
 
 class RetryParams(NamedTuple):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -16,7 +16,6 @@ def test_function():
 
 
 class EmitEventsTest(unittest.TestCase):
-
     @override_settings(DDA_EVENT_HOOK="tests.test_events.test_function")
     def test_import_hook(self):
         hook_path = "tests.test_events.test_function"
@@ -39,20 +38,22 @@ class EmitEventsTest(unittest.TestCase):
             "module 'tests.test_events' has no attribute 'no_function'",
             str(context.exception),
         )
-    
+
     @patch("django_declarative_apis.events._import_hook")
     @patch("django_declarative_apis.events.logger")
-    def test_emit_events_with_hook(
-        self, mock_logger, mock_import_hook
-    ):
+    def test_emit_events_with_hook(self, mock_logger, mock_import_hook):
         event_type, payload = "test_event", {"key": "value"}
         mock_hook_function = Mock()
         mock_import_hook.return_value = mock_hook_function
-        with patch("django_declarative_apis.events.HOOK", "tests.test_events.test_function"):
+        with patch(
+            "django_declarative_apis.events.HOOK", "tests.test_events.test_function"
+        ):
             emit_events(event_type, payload)
             mock_import_hook.assert_called_once_with("tests.test_events.test_function")
             mock_hook_function.assert_called_once_with(event_type, payload)
-            mock_logger.info.assert_called_once_with("Event emitted via custom hook: test_event")
+            mock_logger.info.assert_called_once_with(
+                "Event emitted via custom hook: test_event"
+            )
 
     @patch("django_declarative_apis.events._import_hook")
     @patch("django_declarative_apis.events.logger")
@@ -62,7 +63,9 @@ class EmitEventsTest(unittest.TestCase):
     ):
         event_type, payload = "test_event", {"key": "value"}
         mock_import_hook.return_value.side_effect = Exception("Simulated Exception")
-        with patch("django_declarative_apis.events.HOOK", "tests.test_events.test_function"):
+        with patch(
+            "django_declarative_apis.events.HOOK", "tests.test_events.test_function"
+        ):
             emit_events(event_type, payload)
             mock_logger.error.assert_called_once_with(
                 "Error in custom hook for events: Simulated Exception", exc_info=True

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -6,7 +6,6 @@
 #
 
 import unittest
-import unittest.mock
 from unittest.mock import patch, Mock
 from django_declarative_apis.events import _import_hook, emit_events
 from django.test import override_settings
@@ -42,7 +41,7 @@ class ImportHookTest(unittest.TestCase):
 
 class EmitEventsTest(unittest.TestCase):
     def setUp(self):
-        self.logger = unittest.mock.Mock()
+        self.logger = Mock()
         self.custom_hook = "tests.test_events.test_function"
 
     @patch("django_declarative_apis.events.newrelic_agent")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -10,7 +10,6 @@ import unittest.mock
 from unittest.mock import patch, Mock
 from django_declarative_apis.events import _import_hook, emit_events
 from django.test import override_settings
-from django.conf import settings
 
 
 def test_function():
@@ -46,33 +45,63 @@ class EmitEventsTest(unittest.TestCase):
         self.logger = unittest.mock.Mock()
         self.custom_hook = "tests.test_events.test_function"
 
+    @patch("django_declarative_apis.events.newrelic_agent")
     @patch("django_declarative_apis.events._import_hook")
     @patch("django_declarative_apis.events.logger")
     @override_settings(DDA_EVENT_HOOK="tests.test_events.test_function")
-    def test_emit_events_with_hook(self, mock_logger, mock_import_hook):
+    def test_emit_events_with_hook_and_newrelic(
+        self, mock_logger, mock_import_hook, mock_newrelic_agent
+    ):
         event_type = "test_event"
         payload = {"key": "value"}
 
         mock_hook_function = Mock()
         mock_import_hook.return_value = mock_hook_function
+        mock_newrelic_agent.record_custom_event = Mock()
 
         emit_events(event_type, payload)
         mock_import_hook.assert_called_once_with("tests.test_events.test_function")
         mock_hook_function.assert_called_once_with(event_type, payload)
-        mock_logger.info.assert_called_once_with(
-            f"Event emitted via custom hook: {event_type}"
+        mock_newrelic_agent.record_custom_event.assert_called_once_with(
+            event_type, payload
         )
+        assert mock_logger.info.call_count == 2
+        log_calls = [args[0] for args, _ in mock_logger.info.call_args_list]
+        assert "Event emitted via custom hook: test_event" in log_calls
+        assert "Event emitted to New Relic: test_event" in log_calls
 
     @patch("django_declarative_apis.events.newrelic_agent")
     @patch("django_declarative_apis.events.logger")
     def test_emit_events_with_new_relic(self, mock_logger, mock_newrelic_agent):
-        event_type = "event_type"
+        event_type = "test_event"
         payload = {"key": "value"}
         mock_newrelic_agent.record_custom_event = Mock()
         emit_events(event_type, payload)
         mock_newrelic_agent.record_custom_event.assert_called_once_with(
             event_type, payload
         )
-        mock_logger.info.assert_called_once_with(
-            f"Event emitted to New Relic: {event_type}"
+        assert mock_logger.info.call_count == 2
+        log_calls = [args[0] for args, _ in mock_logger.info.call_args_list]
+        assert (
+            "No custom hook configured. Skipping custom hook for event: test_event"
+            in log_calls
+        )
+        assert "Event emitted to New Relic: test_event" in log_calls
+
+    @patch("django_declarative_apis.events.logger")
+    def test_emit_events_with_no_hook_new_relic(self, mock_logger):
+        event_type = "test_event"
+        payload = {"key": "value"}
+        emit_events(event_type, payload)
+        assert mock_logger.info.call_count == 2
+        log_calls = [args[0] for args, _ in mock_logger.info.call_args_list]
+        assert (
+            "No custom hook configured. Skipping custom hook for event: test_event"
+            in log_calls
+        )
+        assert "No New Relic agent configured. Event test_event not sent." in log_calls
+
+        assert mock_logger.warning.call_count == 1
+        mock_logger.warning.assert_called_once_with(
+            f"No event emitter configured for event: {event_type}. Event not sent."
         )


### PR DESCRIPTION
- [x] Update CHANGELOG.md
- [x] Update README.md (as needed)
- [x] New dependencies were added to `pyproject.toml`
- [x] `pip install` succeeds with a clean virtualenv
- [x] There are new or modified tests that cover changes
- [x] Test coverage is maintained or expanded

This update introduces the ability to use custom hooks for emitting events in Django projects, providing a flexible mechanism for developers to handle application events outside of New Relic. By configuring a custom hook, you can process events in a way that fits your application's needs, whether it's logging, sending notifications, or integrating with other third-party services.

