### PR TITLE
chore: don't log stack traces for client errors @W-17954157

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: set up Python ${{ matrix.python-version }} Django ${{ matrix.django }}
+    - name: set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}

--- a/django_declarative_apis/authentication/oauthlib/endpoint.py
+++ b/django_declarative_apis/authentication/oauthlib/endpoint.py
@@ -79,9 +79,11 @@ class TweakedSignatureOnlyEndpoint(SignatureOnlyEndpoint):
         # prevents malicious users from guessing sensitive information
         v = all((valid_client, valid_signature))
         if not v:
-            log.info("[Failure] request verification failed.")
-            log.info("Valid client: %s", valid_client)
-            log.info("Valid signature: %s", valid_signature)
+            log.info(
+                'ev=oauth1, valid_client=%s, valid_signature=%s, msg="authentication failed"',
+                valid_client,
+                valid_signature,
+            )
 
         if valid_client and not valid_signature:  # TOOPHER
             norm_params = signature.normalize_parameters(request.params)  # TOOPHER

--- a/django_declarative_apis/authentication/oauthlib/request_validator.py
+++ b/django_declarative_apis/authentication/oauthlib/request_validator.py
@@ -61,7 +61,11 @@ class DjangoRequestValidator(RequestValidator):
         self.consumer = oauth_models.get_consumer(client_key)
         if self.consumer is None:
             self.validation_error_message = "consumer_key_unknown"
-            logger.error("invalid consumer")
+            logger.error(
+                'ev=oauth1, error=%s, client_key="%s"',
+                self.validation_error_message,
+                client_key,
+            )
             return False
         return True
 
@@ -69,21 +73,15 @@ class DjangoRequestValidator(RequestValidator):
         try:
             if self.consumer.rsa_public_key_pem:
                 return None
-            else:
-                return self.consumer.secret
-        except Exception as e:  # noqa
-            logger.error(
-                "This should never happen, since consumer is already validated"
-            )
+
+            return self.consumer.secret
+        except Exception:  # noqa
             return ""
 
     def get_rsa_key(self, client_key, request):
         try:
             return self.consumer.rsa_public_key_pem
-        except Exception as e:  # noqa
-            logger.error(
-                "This should never happen, since consumer is already validated"
-            )
+        except Exception:  # noqa
             return ""
 
     @property

--- a/django_declarative_apis/authentication/oauthlib/request_validator.py
+++ b/django_declarative_apis/authentication/oauthlib/request_validator.py
@@ -76,12 +76,14 @@ class DjangoRequestValidator(RequestValidator):
 
             return self.consumer.secret
         except Exception:  # noqa
+            logger.error('ev=dda_client_secret, status=error, key="%s"', client_key)
             return ""
 
     def get_rsa_key(self, client_key, request):
         try:
             return self.consumer.rsa_public_key_pem
         except Exception:  # noqa
+            logger.error('ev=dda_rsa_key, status=error, key="%s"', client_key)
             return ""
 
     @property

--- a/django_declarative_apis/machinery/__init__.py
+++ b/django_declarative_apis/machinery/__init__.py
@@ -448,7 +448,9 @@ class BehavioralEndpointDefinitionRouter:
         try:
             bound_endpoint = self.bind_endpoint_to_request(request, *args, **kwargs)
             logger.info(
-                "Processing request with handler %s",
+                "ev=dda, mehtod=%s, path=%s, handler=%s",
+                request.method,
+                request.path,
                 bound_endpoint.bound_endpoint.__class__.__name__,
             )
             result = bound_endpoint.get_response()

--- a/django_declarative_apis/machinery/__init__.py
+++ b/django_declarative_apis/machinery/__init__.py
@@ -448,7 +448,7 @@ class BehavioralEndpointDefinitionRouter:
         try:
             bound_endpoint = self.bind_endpoint_to_request(request, *args, **kwargs)
             logger.info(
-                "ev=dda, mehtod=%s, path=%s, handler=%s",
+                "ev=dda, method=%s, path=%s, handler=%s",
                 request.method,
                 request.path,
                 bound_endpoint.bound_endpoint.__class__.__name__,

--- a/django_declarative_apis/resources/resource.py
+++ b/django_declarative_apis/resources/resource.py
@@ -263,13 +263,6 @@ class Resource:
             _ = request.POST if request.method == "POST" else request.GET
             status_code, result = meth(request, *args, **kwargs)
         except errors.ClientError as client_error:
-            error_type = type(client_error).__name__
-            message = str(client_error)
-            logger.error(
-                'ev=dda_resource, method=__call__, state=client_exception, type=%s, msg="%s"',
-                error_type,
-                message,
-            )
             status_code = http.client.BAD_REQUEST
             result = self.error_handler(client_error, request, meth, em_format)
         except Exception as e:
@@ -392,7 +385,7 @@ class Resource:
             self.email_exception(rep)
         elif isinstance(error, errors.ClientError):
             logger.info(
-                "ClientError (%s): status_code=%s error_message=%s",
+                'ev=dda, error_type=%s, status_code=%s, error="%s"',
                 error.__class__.__name__,
                 error.status_code,
                 error.as_dict(),

--- a/django_declarative_apis/resources/resource.py
+++ b/django_declarative_apis/resources/resource.py
@@ -265,7 +265,11 @@ class Resource:
         except errors.ClientError as client_error:
             error_type = type(client_error).__name__
             message = str(client_error)
-            logger.error('ev=dda_resource, method=__call__, state=client_exception, type=%s, msg="%s"', error_type, message)
+            logger.error(
+                'ev=dda_resource, method=__call__, state=client_exception, type=%s, msg="%s"',
+                error_type,
+                message,
+            )
             status_code = http.client.BAD_REQUEST
             result = self.error_handler(client_error, request, meth, em_format)
         except Exception as e:
@@ -279,7 +283,8 @@ class Resource:
             emitter, ct = Emitter.get(em_format)
         except ValueError:  # pragma: nocover
             logger.error(
-                "ev=dda_resource method=__call__ state=bad_emitter emitter_format=%s", em_format
+                "ev=dda_resource method=__call__ state=bad_emitter emitter_format=%s",
+                em_format,
             )
             result = rc.BAD_REQUEST
             result.content = "Invalid output format specified '%s'." % em_format

--- a/tests/authentication/oauthlib/test_request_validator.py
+++ b/tests/authentication/oauthlib/test_request_validator.py
@@ -35,7 +35,9 @@ class DjangoRequestValidatorTestCase(django.test.TestCase):
         validator = request_validator.DjangoRequestValidator(request)
 
         self.assertEqual(validator.get_rsa_key(self.consumer.key, request), "")
-
+        self.assertTrue(mock_log.error.called)
+        msg, _ = mock_log.error.call_args[0]
+        self.assertEqual(msg, 'ev=dda_rsa_key, status=error, key="%s"')
         validator.consumer = self.consumer
         self.consumer.rsa_public_key_pem = "something non-null"
 

--- a/tests/authentication/oauthlib/test_request_validator.py
+++ b/tests/authentication/oauthlib/test_request_validator.py
@@ -35,9 +35,6 @@ class DjangoRequestValidatorTestCase(django.test.TestCase):
         validator = request_validator.DjangoRequestValidator(request)
 
         self.assertEqual(validator.get_rsa_key(self.consumer.key, request), "")
-        mock_log.error.assert_called_with(
-            "This should never happen, since consumer is already validated"
-        )
 
         validator.consumer = self.consumer
         self.consumer.rsa_public_key_pem = "something non-null"


### PR DESCRIPTION
[W-17954157](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-17954157)
----
- the 404, 429 errors now don't show the full stack traces 
  - [old](https://splunk-web-noncore.log-analytics.monitoring.aws-esvc1-useast2.aws.sfdc.is/en-US/app/search/search?sid=1741128748.153747_B07B4BA0-F02B-4D7E-9890-2524097BB5BC) -> 91 log events
  - [new](https://splunk-web-noncore.log-analytics.monitoring.aws-esvc1-useast2.aws.sfdc.is/en-US/app/search/search?sid=1741128928.153752_B07B4BA0-F02B-4D7E-9890-2524097BB5BC) -> 11 log events
 - coalesce the log lines around failed oauth1 failures (signature and client)
 - don't log "shouldn't happen" messages for cases where the consumer key is invalid ( `registers authenticator - bad credentials` e2e test)
 - adjust the test Github workflow to test only python versions >= 3.11
----
- [ ] Update CHANGELOG.md
- [ ] Update README.md (as needed)
- [ ] New dependencies were added to `pyproject.toml`
- [ ] `pip install` succeeds with a clean virtualenv
- [ ] There are new or modified tests that cover changes
- [x] Test coverage is maintained or expanded
