### PR TITLE
chore(deps): replace unmaintained oauth2 library with oauthlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased]
+- [PR 187](https://github.com/salesforce/django-declarative-apis/pull/187) Replace unmaintained `oauth2` library with `oauthlib` in test infrastructure.
 
 # [0.34.2]
 - [PR 184](https://github.com/salesforce/django-declarative-apis/pull/184) Add support for Django 5.x

--- a/example/myapp/tests/testutils.py
+++ b/example/myapp/tests/testutils.py
@@ -1,5 +1,6 @@
-import oauth2
 import oauthlib
+import oauthlib.common
+import oauthlib.oauth1
 import time
 
 from django.test.client import ClientHandler
@@ -28,7 +29,9 @@ class OAuthClientHandler(ClientHandler):
 
             # This provides a way for us to override default values for testing.
             oauth_version = request.META.get("oauth_version", "1.0")
-            oauth_nonce = request.META.get("oauth_nonce", oauth2.generate_nonce())
+            oauth_nonce = request.META.get(
+                "oauth_nonce", oauthlib.common.generate_nonce()
+            )
             oauth_client_timestamp = request.META.get(
                 "oauth_timestamp", int(time.time())
             )
@@ -50,22 +53,21 @@ class OAuthClientHandler(ClientHandler):
             # use HMAC-SHA1 signature method
             oauth_signature_data.update({"oauth_signature_method": "HMAC-SHA1"})
 
-            # Create oauth request object to compute signature
-            oauth_request = oauth2.Request.from_consumer_and_token(
-                consumer,
-                None,
-                request.method,
-                request.build_absolute_uri(request.path),
-                all_request_parameters,
-                is_form_encoded=True,
+            oauth1_client = oauthlib.oauth1.Client(
+                consumer.key,
+                client_secret=consumer.secret,
+                signature_method=oauthlib.oauth1.SIGNATURE_HMAC,
             )
 
-            # Add signature to django request
-            signature_method = oauth2.SignatureMethod_HMAC_SHA1()
-            oauth_request.sign_request(signature_method, consumer, None)
-            oauth_signature_data["oauth_signature"] = oauth_request.get_parameter(
-                "oauth_signature"
-            ).decode("utf-8")
+            oauth_request = oauthlib.common.Request(
+                request.build_absolute_uri(request.path),
+                http_method=request.method,
+                body=all_request_parameters,
+            )
+
+            oauth_signature_data["oauth_signature"] = oauth1_client.get_oauth_signature(
+                oauth_request
+            )
 
             use_auth_header_signature = request.META.pop(
                 "use_auth_header_signature", False

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,4 +1,3 @@
 django-declarative-apis
 django-sslserver==0.20
-oauth2==1.9.0.post1
 oauthlib==2.0.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dev = [
   "bumpversion~=0.5",
   "coverage[toml]==6.3.2",
   "ipython~=7.0",
-  "oauth2==1.9.0.post1",
   "pyyaml~=6.0",
   "ruff~=0.1.2",
   "sphinx_rtd_theme==3.0.2",

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -10,8 +10,6 @@ import time
 import urllib.parse
 import logging
 
-import oauth2
-
 from oauthlib import oauth1 as oauthlib_oauth1
 from oauthlib import common as oauthlib_common
 
@@ -33,7 +31,6 @@ _ENCODERS = {
 
 
 class NoLoggingTestRunner(DiscoverRunner):
-
     """Don't log during tests."""
 
     def run_tests(self, test_labels, extra_tests=None, **kwargs):
@@ -106,7 +103,9 @@ class OAuthClientHandler(ClientHandler):
 
             # This provides a way for us to override default values for testing.
             oauth_version = request.META.get("oauth_version", "1.0")
-            oauth_nonce = request.META.get("oauth_nonce", oauth2.generate_nonce())
+            oauth_nonce = request.META.get(
+                "oauth_nonce", oauthlib_common.generate_nonce()
+            )
             oauth_client_timestamp = request.META.get(
                 "oauth_timestamp", cls.get_oauth_client_timestamp()
             )
@@ -144,29 +143,28 @@ class OAuthClientHandler(ClientHandler):
                     body=all_request_parameters,
                 )
 
-                oauth_signature_data[
-                    "oauth_signature"
-                ] = oauth1_client.get_oauth_signature(oauth_request)
+                oauth_signature_data["oauth_signature"] = (
+                    oauth1_client.get_oauth_signature(oauth_request)
+                )
             else:
                 # use HMAC-SHA1 signature method
                 oauth_signature_data.update({"oauth_signature_method": "HMAC-SHA1"})
 
-                # Create oauth request object to compute signature
-                oauth_request = oauth2.Request.from_consumer_and_token(
-                    consumer,
-                    None,
-                    request.method,
-                    request.build_absolute_uri(request.path),
-                    all_request_parameters,
-                    is_form_encoded=True,
+                oauth1_client = oauthlib_oauth1.Client(
+                    consumer.key,
+                    client_secret=consumer.secret,
+                    signature_method=oauthlib_oauth1.SIGNATURE_HMAC,
                 )
 
-                # Add signature to django request
-                signature_method = oauth2.SignatureMethod_HMAC_SHA1()
-                oauth_request.sign_request(signature_method, consumer, None)
-                oauth_signature_data["oauth_signature"] = oauth_request.get_parameter(
-                    "oauth_signature"
-                ).decode("utf-8")
+                oauth_request = oauthlib_common.Request(
+                    request.build_absolute_uri(request.path),
+                    http_method=request.method,
+                    body=all_request_parameters,
+                )
+
+                oauth_signature_data["oauth_signature"] = (
+                    oauth1_client.get_oauth_signature(oauth_request)
+                )
 
             use_auth_header_signature = request.META.pop(
                 "use_auth_header_signature", False

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -143,9 +143,9 @@ class OAuthClientHandler(ClientHandler):
                     body=all_request_parameters,
                 )
 
-                oauth_signature_data["oauth_signature"] = (
-                    oauth1_client.get_oauth_signature(oauth_request)
-                )
+                oauth_signature_data[
+                    "oauth_signature"
+                ] = oauth1_client.get_oauth_signature(oauth_request)
             else:
                 # use HMAC-SHA1 signature method
                 oauth_signature_data.update({"oauth_signature_method": "HMAC-SHA1"})
@@ -162,9 +162,9 @@ class OAuthClientHandler(ClientHandler):
                     body=all_request_parameters,
                 )
 
-                oauth_signature_data["oauth_signature"] = (
-                    oauth1_client.get_oauth_signature(oauth_request)
-                )
+                oauth_signature_data[
+                    "oauth_signature"
+                ] = oauth1_client.get_oauth_signature(oauth_request)
 
             use_auth_header_signature = request.META.pop(
                 "use_auth_header_signature", False


### PR DESCRIPTION
## Summary
- The python-oauth2 package has been unmaintained since 2013, and imports `distutils` — which was removed from the stdlib in Python 3.12 — breaking CI on any fresh test environment.
- Replace oauth2 usages with oauthlib equivalents in test infrastructure: `oauthlib.common.generate_nonce()` for nonces, and `oauthlib.oauth1.Client` + `oauthlib.common.Request` + `get_oauth_signature()` for HMAC-SHA1 signing. This matches the RSA-SHA1 path which already used oauthlib.
- Drop `oauth2==1.9.0.post1` from dev extras in `pyproject.toml` and from `example/requirements.txt`.
- Changes are limited to test infrastructure and the example app — no library code is modified.

## Test plan
- [x] `make test` passes (162 tests, same as before)
- [x] No remaining `oauth2` imports in the codebase