### PR TITLE
chore: move ruff extend-select to [tool.ruff.lint] section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 - [PR 187](https://github.com/salesforce/django-declarative-apis/pull/187) Replace unmaintained `oauth2` library with `oauthlib` in test infrastructure.
+- [PR 188](https://github.com/salesforce/django-declarative-apis/pull/188) Fix ruff deprecation warning by moving `extend-select` to `[tool.ruff.lint]`.
 
 # [0.34.2]
 - [PR 184](https://github.com/salesforce/django-declarative-apis/pull/184) Add support for Django 5.x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dev = [
 
 [tool.ruff]
 extend-exclude = [".heroku"]
+
+[tool.ruff.lint]
 extend-select = ["C901"]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Summary
- Fix ruff deprecation warning by moving `extend-select = ["C901"]` from `[tool.ruff]` into `[tool.ruff.lint]` in `pyproject.toml`.
- `C901` (complex-structure) remains enabled — verified via `ruff check --show-settings`.

## Test plan
- [x] `make static` runs cleanly with no deprecation warning
- [x] Confirmed `C901` is still in the enabled rule set