### PR TITLE
chore: bump ReadTheDocs Python to 3.11

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.11"
 
 python:
   install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [Unreleased]
 - [PR 187](https://github.com/salesforce/django-declarative-apis/pull/187) Replace unmaintained `oauth2` library with `oauthlib` in test infrastructure.
 - [PR 188](https://github.com/salesforce/django-declarative-apis/pull/188) Fix ruff deprecation warning by moving `extend-select` to `[tool.ruff.lint]`.
+- [PR 190](https://github.com/salesforce/django-declarative-apis/pull/190) Bump ReadTheDocs build to Python 3.11 to satisfy `coverage` 7.14.0's `>=3.10` requirement.
 
 # [0.34.2]
 - [PR 184](https://github.com/salesforce/django-declarative-apis/pull/184) Add support for Django 5.x


### PR DESCRIPTION
## Summary
- ReadTheDocs builds were failing because `coverage==7.14.0` (installed via the `[dev]` extra) requires Python `>=3.10`, but `.readthedocs.yaml` pinned the build toolchain to 3.9.
- Bumps the RTD Python version to 3.11 to unblock docs builds.

## Test plan
- [ ] ReadTheDocs build passes on this branch