### PR TITLE
docs: document release procedure in README

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,5 +1,6 @@
 #
-# Publishes the release to PyPI and docs to github pages
+# Publishes the release to PyPI. Docs are built and published separately
+# by ReadTheDocs.
 #
 
 name: "publish release"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR 187](https://github.com/salesforce/django-declarative-apis/pull/187) Replace unmaintained `oauth2` library with `oauthlib` in test infrastructure.
 - [PR 188](https://github.com/salesforce/django-declarative-apis/pull/188) Fix ruff deprecation warning by moving `extend-select` to `[tool.ruff.lint]`.
 - [PR 190](https://github.com/salesforce/django-declarative-apis/pull/190) Bump ReadTheDocs build to Python 3.11 to satisfy `coverage` 7.14.0's `>=3.10` requirement.
+- [PR 191](https://github.com/salesforce/django-declarative-apis/pull/191) Document the release procedure in the README.
 
 # [0.34.2]
 - [PR 184](https://github.com/salesforce/django-declarative-apis/pull/184) Add support for Django 5.x

--- a/README.md
+++ b/README.md
@@ -102,3 +102,32 @@ Optional: Implement Custom Event Hooks for Event Emission
 # settings.py 
 DDA_EVENT_HOOK = "my_app.hooks.custom_event_handler"
 ```
+
+Releasing
+=========
+
+Releases are published to PyPI by the `publish release` GitHub Action, which
+runs when a GitHub Release is created from a version tag.
+
+1. Bump the version with `bumpversion` so that `pyproject.toml` and
+   `docs/source/conf.py` stay in sync:
+
+   ```bash
+   bumpversion patch   # or minor / major
+   ```
+
+2. Push the resulting commit and tag (the tag will look like `v0.34.3`):
+
+   ```bash
+   git push --follow-tags
+   ```
+
+3. Create a GitHub Release from the new tag at
+   https://github.com/salesforce/django-declarative-apis/releases/new.
+   Creating the release triggers `.github/workflows/publish-release.yml`,
+   which builds the sdist + wheel and uploads them to PyPI. The workflow can
+   also be re-run manually from the Actions tab via `workflow_dispatch` if
+   the publish step needs to be retried.
+
+Documentation is built and published independently by ReadTheDocs from the
+repository, so no manual docs step is required as part of cutting a release.

--- a/README.md
+++ b/README.md
@@ -109,25 +109,29 @@ Releasing
 Releases are published to PyPI by the `publish release` GitHub Action, which
 runs when a GitHub Release is created from a version tag.
 
-1. Bump the version with `bumpversion` so that `pyproject.toml` and
-   `docs/source/conf.py` stay in sync:
+1. On a release branch, bump the version with `bumpversion` so that
+   `pyproject.toml` and `docs/source/conf.py` stay in sync, and roll the
+   `# [Unreleased]` section of `CHANGELOG.md` into a new `# [X.Y.Z]` section
+   for the version being released:
 
    ```bash
    bumpversion patch   # or minor / major
    ```
 
-2. Push the resulting commit and tag (the tag will look like `v0.34.3`):
+   `bumpversion` does not create a tag in this repo's configuration; the tag
+   is created in step 3 from the GitHub Release.
 
-   ```bash
-   git push --follow-tags
-   ```
+2. Open a pull request with the version bump and CHANGELOG update, get it
+   reviewed, and merge it to `main`.
 
-3. Create a GitHub Release from the new tag at
-   https://github.com/salesforce/django-declarative-apis/releases/new.
-   Creating the release triggers `.github/workflows/publish-release.yml`,
-   which builds the sdist + wheel and uploads them to PyPI. The workflow can
-   also be re-run manually from the Actions tab via `workflow_dispatch` if
-   the publish step needs to be retried.
+3. Create a GitHub Release at
+   https://github.com/salesforce/django-declarative-apis/releases/new,
+   targeting the merge commit on `main` and creating a new tag of the form
+   `v0.34.3`. Publishing the Release triggers
+   `.github/workflows/publish-release.yml`, which builds the sdist + wheel
+   and uploads them to PyPI. The workflow can also be re-run manually from
+   the Actions tab via `workflow_dispatch` if the publish step needs to be
+   retried.
 
 Documentation is built and published independently by ReadTheDocs from the
 repository, so no manual docs step is required as part of cutting a release.

--- a/README.md
+++ b/README.md
@@ -109,25 +109,31 @@ Releasing
 Releases are published to PyPI by the `publish release` GitHub Action, which
 runs when a GitHub Release is created from a version tag.
 
-1. On a release branch, bump the version with `bumpversion` so that
-   `pyproject.toml` and `docs/source/conf.py` stay in sync, and roll the
-   `# [Unreleased]` section of `CHANGELOG.md` into a new `# [X.Y.Z]` section
-   for the version being released:
+1. Create a release branch off the latest `main`:
+
+   ```bash
+   git checkout main && git pull
+   git checkout -b release-X.Y.Z
+   ```
+
+2. Bump the version with `bumpversion`. This keeps `pyproject.toml` and
+   `docs/source/conf.py` in sync:
 
    ```bash
    bumpversion patch   # or minor / major
    ```
 
-   `bumpversion` does not create a tag in this repo's configuration; the tag
-   is created in step 3 from the GitHub Release.
+3. Update `CHANGELOG.md`: rename the `# [Unreleased]` heading to
+   `# [X.Y.Z]` (matching the new version), and add a fresh empty
+   `# [Unreleased]` section above it for future entries.
 
-2. Open a pull request with the version bump and CHANGELOG update, get it
-   reviewed, and merge it to `main`.
+4. Push the branch and open a pull request. Get it reviewed and merge it
+   into `main`.
 
-3. Create a GitHub Release at
+5. Create a GitHub Release at
    https://github.com/salesforce/django-declarative-apis/releases/new,
    targeting the merge commit on `main` and creating a new tag of the form
-   `v0.34.3`. Publishing the Release triggers
+   `vX.Y.Z`. Publishing the Release triggers
    `.github/workflows/publish-release.yml`, which builds the sdist + wheel
    and uploads them to PyPI. The workflow can also be re-run manually from
    the Actions tab via `workflow_dispatch` if the publish step needs to be

--- a/README.md
+++ b/README.md
@@ -109,11 +109,12 @@ Releasing
 Releases are published to PyPI by the `publish release` GitHub Action, which
 runs when a GitHub Release is created from a version tag.
 
-1. Create a release branch off the latest `main`:
+1. Create a release branch off the latest `main`. Past releases have used
+   `release/X.Y.Z` (e.g. `release/0.25.3`):
 
    ```bash
    git checkout main && git pull
-   git checkout -b release-X.Y.Z
+   git checkout -b release/X.Y.Z
    ```
 
 2. Bump the version with `bumpversion`. This keeps `pyproject.toml` and


### PR DESCRIPTION
## Summary
- Adds a `Releasing` section to `README.md` covering the manual release flow: bump version with `bumpversion`, push the tag, create a GitHub Release to trigger `publish-release.yml`, which publishes to PyPI.
- Notes that ReadTheDocs handles docs publishing separately, so no manual docs step is required.

## Test plan
- [ ] README renders correctly on GitHub