### PR TITLE
fix: keep instances alive in filter model cache to prevent id() reuse collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR 188](https://github.com/salesforce/django-declarative-apis/pull/188) Fix ruff deprecation warning by moving `extend-select` to `[tool.ruff.lint]`.
 - [PR 190](https://github.com/salesforce/django-declarative-apis/pull/190) Bump ReadTheDocs build to Python 3.11 to satisfy `coverage` 7.14.0's `>=3.10` requirement.
 - [PR 191](https://github.com/salesforce/django-declarative-apis/pull/191) Document the release procedure in the README.
+- [PR 194](https://github.com/salesforce/django-declarative-apis/pull/194) Fix filter model cache serving the wrong object's callable field value when a garbage-collected instance's `id()` is reused during serialization.
 
 # [0.34.2]
 - [PR 184](https://github.com/salesforce/django-declarative-apis/pull/184) Add support for Django 5.x

--- a/django_declarative_apis/machinery/filtering.py
+++ b/django_declarative_apis/machinery/filtering.py
@@ -87,6 +87,11 @@ def _is_reverse_relation(field):
     return isinstance(field, ForeignObjectRel)
 
 
+# Sentinel prefix for entries that only exist to keep an instance alive in the
+# per-request model cache (see `_get_callable_field_value_with_cache`).
+_KEEPALIVE_CACHE_KEY = object()
+
+
 def _get_callable_field_value_with_cache(inst, field_name, model_cache, field_type):
     cache_relation = True
 
@@ -106,8 +111,9 @@ def _get_callable_field_value_with_cache(inst, field_name, model_cache, field_ty
         val_cls = field_meta.related_model
         cache_key = _make_model_cache_key(val_cls, fk_pk)
     else:
-        # not a foreign key.  Cache it by (inst, field_name) - it won't be a cache hit on another instance, but
-        # will be cached if this same inst is returned later in the response
+        # not a foreign key.  Cache it by (id(inst), field_name) - it won't be a
+        # cache hit on another instance, but will be cached if this same inst is
+        # returned later in the response.
         cache_key = (id(inst), field_name)
 
     if cache_key in model_cache:
@@ -121,6 +127,14 @@ def _get_callable_field_value_with_cache(inst, field_name, model_cache, field_ty
             # need to get an iterable to proceed
             result = result.all()
         model_cache[cache_key] = result
+
+        if not cache_relation:
+            # `cache_key` is derived from `id(inst)`, and CPython reuses object
+            # ids once an object is garbage-collected. Keep a strong reference to
+            # `inst` for the lifetime of this per-request cache so a later object
+            # cannot be allocated at the same address, collide with this key, and
+            # return the wrong object's cached value.
+            model_cache[(_KEEPALIVE_CACHE_KEY, id(inst))] = inst
     return result
 
 

--- a/tests/machinery/test_base.py
+++ b/tests/machinery/test_base.py
@@ -793,6 +793,30 @@ class FilterCachingUnhashableTestCase(django.test.TestCase):
             self.assertEqual(1, filtered["branch_p"]["id"])
 
 
+class CallableFieldCacheKeepAliveTestCase(django.test.TestCase):
+    def test_callable_field_cache_retains_inst_reference(self):
+        # Callable fields on non-model (or reverse-relation) instances are cached
+        # by (id(inst), field_name). CPython reuses object ids after an object is
+        # garbage-collected, so without keeping a strong reference to `inst` a
+        # later object allocated at the same address would collide with the key
+        # and receive the wrong object's cached value. Verify the cache retains
+        # `inst` so its id cannot be reused for the cache's lifetime.
+        class _NonModel:
+            pass
+
+        model_cache = {}
+        inst = _NonModel()
+        result = filtering._get_callable_field_value_with_cache(
+            inst, "field", model_cache, lambda i: "value"
+        )
+
+        self.assertEqual(result, "value")
+        self.assertTrue(
+            any(value is inst for value in model_cache.values()),
+            "model cache must retain a reference to inst to prevent id() reuse",
+        )
+
+
 class ResourceUpdateEndpointDefinitionTestCase(
     testutils.RequestCreatorMixin, django.test.TestCase
 ):


### PR DESCRIPTION
## Summary

`_get_callable_field_value_with_cache` (in `machinery/filtering.py`) caches callable/function field values for instances that are **not** foreign-key model fields (reverse relations, or non-model objects such as pydantic/proxy instances) under a key of `(id(inst), field_name)` in the per-request `model_cache`.

The cache stores the computed **result** but does not retain a reference to `inst`. CPython reuses object ids once an object is garbage-collected, so if `inst` is collected mid-serialization and a later object is allocated at the same address, its lookup collides with the stale key and it is served **the wrong object's** cached field value.

This path is active whenever `DDA_FILTER_MODEL_CACHING_ENABLED` is `True`. In practice a single response could serialize one object's callable field value onto a different object. It is timing/GC-dependent and low-probability, but it is a correctness issue rather than only a performance one.

## Reproduction

It surfaced downstream as an intermittent test failure where two serializations of the same object graph disagreed on a callable field. It reproduces far more readily on **Python 3.14** and under **coverage instrumentation**, both of which shift allocation/GC timing enough to make the id reuse happen within a single serialization pass. A fully deterministic behavioral reproduction is inherently timing-dependent, so the added test asserts the fix's invariant directly (see below).

## Fix

Keep a strong reference to `inst` in `model_cache` for the id-keyed branch, so its `id()` cannot be reused for the lifetime of the per-request cache. The reference is stored under a sentinel-prefixed key so it never collides with real cache entries, and `model_cache` is only ever accessed by key (never iterated), so the extra entries are inert.

## Test

`CallableFieldCacheKeepAliveTestCase` verifies that after caching a callable field on a non-model instance, `model_cache` retains a reference to the instance — the invariant that makes id reuse impossible. Without the fix the cache holds only the result, so the instance can be collected and its id reused.

## CHANGELOG

Added under `[Unreleased]`.