### PR TITLE
release v0.34.3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.34.2
+current_version = 0.34.3
 
 [bumpversion:file:pyproject.toml]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased]
+
+# [0.34.3]
 - [PR 187](https://github.com/salesforce/django-declarative-apis/pull/187) Replace unmaintained `oauth2` library with `oauthlib` in test infrastructure.
 - [PR 188](https://github.com/salesforce/django-declarative-apis/pull/188) Fix ruff deprecation warning by moving `extend-select` to `[tool.ruff.lint]`.
 - [PR 190](https://github.com/salesforce/django-declarative-apis/pull/190) Bump ReadTheDocs build to Python 3.11 to satisfy `coverage` 7.14.0's `>=3.10` requirement.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,7 +75,7 @@ author = "Salesforce"
 # built documents.
 
 # The full version, including alpha/beta/rc tags.
-release = "0.34.2"  # set by bumpversion
+release = "0.34.3"  # set by bumpversion
 
 # The short X.Y version.
 version = release.rsplit(".", 1)[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-declarative-apis"
-version = "0.34.2"  # set by bumpversion
+version = "0.34.3"  # set by bumpversion
 description = "Simple, readable, declarative APIs for Django"
 readme = "README.md"
 dependencies = [


### PR DESCRIPTION
Release 0.34.3.

Bumps the version to `0.34.3` (`pyproject.toml`, `docs/source/conf.py`, `.bumpversion.cfg`) and rolls the `# [Unreleased]` changelog entries into a `# [0.34.3]` section.

Included in this release:
- [PR 187](https://github.com/salesforce/django-declarative-apis/pull/187) Replace unmaintained `oauth2` library with `oauthlib` in test infrastructure.
- [PR 188](https://github.com/salesforce/django-declarative-apis/pull/188) Fix ruff deprecation warning by moving `extend-select` to `[tool.ruff.lint]`.
- [PR 190](https://github.com/salesforce/django-declarative-apis/pull/190) Bump ReadTheDocs build to Python 3.11 to satisfy `coverage` 7.14.0's `>=3.10` requirement.
- [PR 191](https://github.com/salesforce/django-declarative-apis/pull/191) Document the release procedure in the README.
- [PR 194](https://github.com/salesforce/django-declarative-apis/pull/194) Fix filter model cache serving the wrong object's callable field value when a garbage-collected instance's `id()` is reused during serialization.

After this merges to `main`, publishing a GitHub Release with tag `v0.34.3` triggers `publish-release.yml`, which builds and uploads the sdist + wheel to PyPI.