### PR TITLE
fix: don't cache to-many relations by manager address in filter model cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased]
+- Fix filter model cache serving the wrong object's collection for callable filters over to-many relations (forward `GenericRelation`, `ManyToManyField`, or reverse FK). Such fields were mistaken for scalar foreign keys and cached by a key derived from a transient related manager's memory address; after garbage collection that address could be reused by another owner's manager, forging a cache hit and returning the wrong collection. To-many relations now fall back to the per-instance cache key.
 
 # [0.34.3]
 - [PR 187](https://github.com/salesforce/django-declarative-apis/pull/187) Replace unmaintained `oauth2` library with `oauthlib` in test infrastructure.

--- a/django_declarative_apis/machinery/filtering.py
+++ b/django_declarative_apis/machinery/filtering.py
@@ -97,8 +97,23 @@ def _get_callable_field_value_with_cache(inst, field_name, model_cache, field_ty
 
     try:
         field_meta = inst._meta.get_field(field_name)
-        if not _is_relation(field_meta) or _is_reverse_relation(field_meta):
-            # no `attname` in reverse relations
+        if (
+            not _is_relation(field_meta)
+            or _is_reverse_relation(field_meta)
+            or field_meta.one_to_many
+            or field_meta.many_to_many
+        ):
+            # Only a scalar (to-one) relation can be cached across instances by
+            # (model, fk_pk): it has a single related pk stored in `attname`.
+            # - reverse relations (`ForeignObjectRel`) have no `attname`.
+            # - to-many relations (`field.one_to_many` covers reverse FKs and
+            #   forward `GenericRelation`; `field.many_to_many` covers
+            #   `ManyToManyField`) have no single child pk. For them
+            #   `getattr(inst, attname)` returns a transient related *manager*,
+            #   whose memory address would leak into the cache key. CPython
+            #   reuses addresses after GC, so a later owner's manager could
+            #   collide with this key and be served the wrong collection.
+            # In every such case fall back to the per-instance key below.
             cache_relation = False
     except (AttributeError, FieldDoesNotExist):
         # inst doesn't look like a django model

--- a/tests/filters.py
+++ b/tests/filters.py
@@ -75,6 +75,21 @@ INEFFICIENT_FUNCTION_FILTERS = {
     },
 }
 
+# Two distinct owners expose a to-many collection through a *callable* filter, the
+# same shape that surfaced the model-cache collision in downstream code: a
+# `GenericRelation` (one_to_many) resolved via `getattr(inst, "items")`.
+TO_MANY_GENERIC_RELATION_FILTERS = {
+    models.TaggableItem: {"name": ALWAYS},
+    models.TaggedOwnerA: {"items": lambda inst: inst.items},
+    models.TaggedOwnerB: {"items": lambda inst: inst.items},
+}
+
+# Same, for a `ManyToManyField` (many_to_many) resolved via `getattr(inst, "targets")`.
+TO_MANY_M2M_FILTERS = {
+    models.M2MTarget: {"name": ALWAYS},
+    models.M2MOwner: {"targets": lambda inst: inst.targets},
+}
+
 RENAMED_EXPANDABLE_MODEL_FIELDS = {
     str: ALWAYS,
     int: ALWAYS,

--- a/tests/machinery/test_base.py
+++ b/tests/machinery/test_base.py
@@ -4,12 +4,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
+import gc
 import http
 import json
 import unittest
 
 import django.core.exceptions
 import django.test
+from django.contrib.contenttypes.models import ContentType
 from django.test.utils import override_settings
 import kombu.exceptions
 from unittest import mock
@@ -815,6 +817,199 @@ class CallableFieldCacheKeepAliveTestCase(django.test.TestCase):
             any(value is inst for value in model_cache.values()),
             "model cache must retain a reference to inst to prevent id() reuse",
         )
+
+
+class CallableFieldCacheRelationBranchTestCase(django.test.TestCase):
+    """Guards the branch decision in `_get_callable_field_value_with_cache`.
+
+    A callable filter over a *scalar* (to-one) relation must still be cached by
+    ``(related_model, fk_pk)`` so distinct owners pointing at the same child get a
+    cache hit. A callable filter over a *to-many* relation (reverse FK, forward
+    ``GenericRelation``, or ``ManyToManyField``) must NOT take that path: there is
+    no single child pk, and ``getattr(inst, attname)`` returns a transient manager
+    whose memory address would leak into the cache key and collide across owners.
+    """
+
+    def _branch_for(self, inst, field_name):
+        """Replay the branch decision and return (cache_relation, cache_key)."""
+        captured = {}
+
+        def field_type(i):
+            # Record the key the function was invoked under, then return a
+            # sentinel so we never actually hit the database.
+            return "sentinel"
+
+        model_cache = {}
+        # Instrument `_make_model_cache_key` so we can tell which branch ran:
+        # the scalar branch builds a (model, pk) key; the fallback builds
+        # (id(inst), field_name) directly.
+        original = filtering._make_model_cache_key
+        keys_built = []
+
+        def spy(klass, pk):
+            key = original(klass, pk)
+            keys_built.append(key)
+            return key
+
+        filtering._make_model_cache_key = spy
+        try:
+            filtering._get_callable_field_value_with_cache(
+                inst, field_name, model_cache, field_type
+            )
+        finally:
+            filtering._make_model_cache_key = original
+
+        captured["scalar_key_built"] = bool(keys_built)
+        captured["keys_built"] = keys_built
+        captured["cache_keys"] = [
+            k for k in model_cache if k[0] is not filtering._KEEPALIVE_CACHE_KEY
+        ]
+        return captured
+
+    def test_scalar_fk_still_uses_model_pk_cache_key(self):
+        # Original behavior must be preserved: a to-one FK is keyed by (model, pk).
+        leaf = models.InefficientLeaf.objects.create(id=1)
+        branch = models.InefficientBranchA.objects.create(id=1, leaf=leaf)
+
+        result = self._branch_for(branch, "leaf")
+
+        self.assertTrue(
+            result["scalar_key_built"],
+            "scalar FK must be cached by (related_model, fk_pk)",
+        )
+        # The key is (model, str(pk)) — a stable pk, not a manager address.
+        (model, pk) = result["keys_built"][0]
+        self.assertEqual(model, models.InefficientLeaf)
+        self.assertEqual(pk, str(leaf.pk))
+
+    def test_scalar_fk_dedupes_across_distinct_owners(self):
+        # Two different owners pointing at the same child hit the shared key.
+        leaf = models.InefficientLeaf.objects.create(id=1)
+        branch_a = models.InefficientBranchA.objects.create(id=1, leaf=leaf)
+        branch_b = models.InefficientBranchB.objects.create(id=1, leaf=leaf)
+
+        calls = []
+
+        def field_type(inst):
+            calls.append(inst)
+            return inst.leaf
+
+        model_cache = {}
+        filtering._get_callable_field_value_with_cache(
+            branch_a, "leaf", model_cache, field_type
+        )
+        filtering._get_callable_field_value_with_cache(
+            branch_b, "leaf", model_cache, field_type
+        )
+
+        # Second owner should have been a cache hit -> field_type called once.
+        self.assertEqual(
+            len(calls), 1, "distinct owners of the same child must share the cache"
+        )
+
+    def test_generic_relation_not_cached_by_manager_address(self):
+        # A forward GenericRelation is one_to_many -> must NOT build a (model, pk)
+        # key from a transient manager.
+        owner = models.TaggedOwnerA.objects.create(name="owner")
+
+        result = self._branch_for(owner, "items")
+
+        self.assertFalse(
+            result["scalar_key_built"],
+            "GenericRelation (one_to_many) must not use the scalar-FK cache key",
+        )
+        # It falls back to the per-instance key.
+        self.assertEqual(result["cache_keys"], [(id(owner), "items")])
+
+    def test_many_to_many_not_cached_by_manager_address(self):
+        # A ManyToManyField is many_to_many -> must NOT build a (model, pk) key.
+        owner = models.M2MOwner.objects.create(name="owner")
+
+        result = self._branch_for(owner, "targets")
+
+        self.assertFalse(
+            result["scalar_key_built"],
+            "ManyToManyField (many_to_many) must not use the scalar-FK cache key",
+        )
+        self.assertEqual(result["cache_keys"], [(id(owner), "targets")])
+
+
+class ToManyGenericRelationCollisionTestCase(django.test.TestCase):
+    """End-to-end reproduction of the model-cache collision the fix prevents.
+
+    Two distinct owners each expose a to-many ``GenericRelation`` through a
+    callable filter, serialized within a single ``apply_filters_to_object`` call
+    (shared ``model_cache``). Before the fix, the first owner's collection was
+    cached under a key derived from its transient manager's memory address; once
+    that manager was garbage-collected the address could be reused by the second
+    owner's manager, forging an identical key and serving owner A's items on
+    owner B. We force that GC window with ``gc.collect()`` and assert each owner
+    keeps its own collection.
+    """
+
+    def setUp(self):
+        super().setUp()
+        owner_a = models.TaggedOwnerA.objects.create(name="owner-a")
+        owner_b = models.TaggedOwnerB.objects.create(name="owner-b")
+        ct_a = ContentType.objects.get_for_model(models.TaggedOwnerA)
+        ct_b = ContentType.objects.get_for_model(models.TaggedOwnerB)
+        # Owner A owns TWO items; owner B owns ONE — distinct lists and sizes so a
+        # collision is unambiguous.
+        models.TaggableItem.objects.create(
+            name="a1", content_type=ct_a, object_id=owner_a.pk
+        )
+        models.TaggableItem.objects.create(
+            name="a2", content_type=ct_a, object_id=owner_a.pk
+        )
+        models.TaggableItem.objects.create(
+            name="b1", content_type=ct_b, object_id=owner_b.pk
+        )
+        self.owner_a_id = owner_a.pk
+        self.owner_b_id = owner_b.pk
+
+    def _serialize_both_owners(self):
+        # Serialize both owners under one shared model_cache, forcing GC between
+        # them so a freed manager's address can be reused by the next owner.
+        owner_a = models.TaggedOwnerA.objects.get(pk=self.owner_a_id)
+        owner_b = models.TaggedOwnerB.objects.get(pk=self.owner_b_id)
+
+        model_cache = {}
+        filter_def = filters.TO_MANY_GENERIC_RELATION_FILTERS
+
+        result_a = filtering._apply_filters_to_object(
+            owner_a,
+            filter_def,
+            expand_children={},
+            klass=models.TaggedOwnerA,
+            filter_cache={},
+            model_cache=model_cache,
+        )
+        gc.collect()
+        result_b = filtering._apply_filters_to_object(
+            owner_b,
+            filter_def,
+            expand_children={},
+            klass=models.TaggedOwnerB,
+            filter_cache={},
+            model_cache=model_cache,
+        )
+        return result_a, result_b
+
+    def test_each_owner_keeps_its_own_generic_relation(self):
+        with override_settings(
+            DDA_FILTER_MODEL_CACHING_ENABLED=True, DDA_FILTER_CACHE_DEBUG_LOG=True
+        ):
+            # Run several rounds so an address collision, if possible, is likely
+            # to occur under GC pressure. With the fix, every round is correct.
+            for _ in range(50):
+                result_a, result_b = self._serialize_both_owners()
+
+                names_a = sorted(item["name"] for item in result_a["items"])
+                names_b = sorted(item["name"] for item in result_b["items"])
+                self.assertEqual(
+                    names_a, ["a1", "a2"], "owner A must keep its own 2 items"
+                )
+                self.assertEqual(names_b, ["b1"], "owner B must keep its own 1 item")
 
 
 class ResourceUpdateEndpointDefinitionTestCase(

--- a/tests/models.py
+++ b/tests/models.py
@@ -5,6 +5,8 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 import pydantic
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
 
@@ -71,6 +73,40 @@ class InefficientRoot(models.Model):
     id = models.IntegerField(primary_key=True)
     branch_a = models.ForeignKey(InefficientBranchA, on_delete=models.CASCADE)
     branch_b = models.ForeignKey(InefficientBranchB, on_delete=models.CASCADE)
+
+
+class TaggableItem(models.Model):
+    """A generic-relation child, pointed at by a `GenericForeignKey`."""
+
+    name = models.CharField(max_length=100)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
+    object_id = models.PositiveIntegerField()
+    content_object = GenericForeignKey("content_type", "object_id")
+
+
+class TaggedOwnerA(models.Model):
+    """An owner exposing a to-many `GenericRelation` (``items``)."""
+
+    name = models.CharField(max_length=100)
+    items = GenericRelation(TaggableItem)
+
+
+class TaggedOwnerB(models.Model):
+    """A second, distinct owner of the same `GenericRelation` collection."""
+
+    name = models.CharField(max_length=100)
+    items = GenericRelation(TaggableItem)
+
+
+class M2MTarget(models.Model):
+    name = models.CharField(max_length=100)
+
+
+class M2MOwner(models.Model):
+    """An owner exposing a to-many `ManyToManyField` (``targets``)."""
+
+    name = models.CharField(max_length=100)
+    targets = models.ManyToManyField(M2MTarget)
 
 
 class PydanticBranch(pydantic.BaseModel):


### PR DESCRIPTION
## Summary

`_get_callable_field_value_with_cache` (in `machinery/filtering.py`) decides how to
cache a callable/function filter field in the per-request `model_cache`. For a
relation it takes the "scalar foreign key" fast path — keying on
`(related_model, fk_pk)` so that distinct owners pointing at the *same* child
get a cache hit.

The guard that excludes non-scalar relations from that fast path was:

```python
if not _is_relation(field_meta) or _is_reverse_relation(field_meta):
    cache_relation = False   # _is_reverse_relation == isinstance(field, ForeignObjectRel)
```

This only recognizes Django's auto-generated **reverse** descriptors
(`ForeignObjectRel` subclasses like `ManyToOneRel`). It does **not** recognize
forward-declared **to-many** fields — `GenericRelation` (`one_to_many=True`) and
`ManyToManyField` (`many_to_many=True`) — which live in the forward `Field`
hierarchy, not under `ForeignObjectRel`.

So a to-many field was misclassified as a scalar FK and sent down the caching
path, where:

```python
fk_pk = getattr(inst, field_meta.attname)   # to-many -> returns a *Manager*, not a pk
cache_key = _make_model_cache_key(val_cls, fk_pk)   # -> (val_cls, "<...Manager object at 0x7f...>")
```

For a to-many relation there is no single child pk. `getattr` returns a transient
related **manager**, and `_make_model_cache_key` folds `str(manager)` — which
includes its **memory address** — into the cache key. CPython reuses addresses
once an object is garbage-collected, so a later owner's manager can be allocated
at the same address, produce an identical key, hit the cache, and be served **the
wrong owner's collection**.

This is timing/GC-dependent and low-probability, but it is a **correctness** bug,
not just a performance one. Downstream it surfaced as an intermittent test failure
where two serializations of the same object graph disagreed on a to-many field
(`Requester.consumers` / `Authenticator.consumers`, a `GenericRelation`).

### Relationship to #194

#194 fixed the same class of address-reuse collision, but in the **other** branch:
it pins `inst` alive so the `(id(inst), field_name)` key used for non-relations
can't be reused. That keepalive never runs for fields that take the scalar-FK
branch, so it does not cover this case. This PR is complementary — it stops
to-many relations from entering the scalar-FK branch in the first place.

## Fix

Broaden the guard so **any** to-many relation is routed to the safe per-instance
fallback key `(id(inst), field_name)` (which #194 already made collision-proof)
instead of the scalar `(model, pk)` path:

```python
if (
    not _is_relation(field_meta)
    or _is_reverse_relation(field_meta)
    or field_meta.one_to_many      # reverse FK AND forward GenericRelation
    or field_meta.many_to_many     # ManyToManyField
):
    cache_relation = False
```

Using Django's cardinality flags (`one_to_many`, `many_to_many`) rather than an
`isinstance(GenericRelation)` check closes the entire blind spot: `one_to_many`
covers both reverse FKs and `GenericRelation`; `many_to_many` covers
`ManyToManyField`. The scalar-FK fast path stays reserved for genuine to-one
relations, so cross-owner dedup for real FKs is unchanged.

## Test plan

Added to `tests/machinery/test_base.py` (with supporting models in
`tests/models.py` and filters in `tests/filters.py`):

**`CallableFieldCacheRelationBranchTestCase`** — unit-level assertions on the
branch decision, spying on `_make_model_cache_key`:
- `test_scalar_fk_still_uses_model_pk_cache_key` — a to-one FK is still keyed by
  `(related_model, str(fk_pk))` (no behavior change).
- `test_scalar_fk_dedupes_across_distinct_owners` — two owners of the same child
  still share the cache (the callable runs once).
- `test_generic_relation_not_cached_by_manager_address` — a forward
  `GenericRelation` does **not** build a `(model, pk)` key and falls back to
  `(id(inst), field_name)`.
- `test_many_to_many_not_cached_by_manager_address` — same for `ManyToManyField`.

**`ToManyGenericRelationCollisionTestCase.test_each_owner_keeps_its_own_generic_relation`**
— end-to-end reproduction: two distinct owners (A owns 2 items, B owns 1) are
serialized under a shared `model_cache` with `DDA_FILTER_MODEL_CACHING_ENABLED=True`,
forcing `gc.collect()` between them and looping 50× to provoke address reuse.
Asserts each owner keeps its own collection.

Verified the three to-many tests **fail without** the guard change and **pass with**
it; the two scalar-FK tests pass **both** ways (fix preserves original caching and
doesn't over-broaden). Full DDA suite passes; `ruff check` + `ruff format` clean.

## Checklist

- [x] Update CHANGELOG.md
- [ ] Update README.md (as needed) — not needed
- [ ] New dependencies were added to `pyproject.toml` — none
- [x] `pip install` succeeds with a clean virtualenv
- [x] There are new or modified tests that cover changes
- [x] Test coverage is maintained or expanded
