### PR TITLE
chore: add GUSINFO line to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
 #ECCN:Open Source
+#GUSINFO:Verification as a Service (VaaS),VaaS


### PR DESCRIPTION
Adds the `#GUSINFO:` line to `CODEOWNERS`, identifying the owning team and product tag so ownership metadata is complete.

Follows the format documented in the [`oss-template` CODEOWNERS](https://github.com/salesforce/oss-template/blob/main/CODEOWNERS) and matches the sibling [`django-request-queue-timeout`](https://github.com/salesforce/django-request-queue-timeout/blob/main/CODEOWNERS) repo.

```
#GUSINFO:Verification as a Service (VaaS),VaaS
```