### PR TITLE
release v0.34.4

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.34.3
+current_version = 0.34.4
 
 [bumpversion:file:pyproject.toml]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased]
-- Fix filter model cache serving the wrong object's collection for callable filters over to-many relations (forward `GenericRelation`, `ManyToManyField`, or reverse FK). Such fields were mistaken for scalar foreign keys and cached by a key derived from a transient related manager's memory address; after garbage collection that address could be reused by another owner's manager, forging a cache hit and returning the wrong collection. To-many relations now fall back to the per-instance cache key.
+
+# [0.34.4]
+- [PR 197](https://github.com/salesforce/django-declarative-apis/pull/197) Fix filter model cache serving the wrong object's collection for callable filters over to-many relations (forward `GenericRelation`, `ManyToManyField`, or reverse FK). Such fields were mistaken for scalar foreign keys and cached by a key derived from a transient related manager's memory address; after garbage collection that address could be reused by another owner's manager, forging a cache hit and returning the wrong collection. To-many relations now fall back to the per-instance cache key.
 
 # [0.34.3]
 - [PR 187](https://github.com/salesforce/django-declarative-apis/pull/187) Replace unmaintained `oauth2` library with `oauthlib` in test infrastructure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [Unreleased]
 
 # [0.34.4]
-- [PR 197](https://github.com/salesforce/django-declarative-apis/pull/197) Fix filter model cache serving the wrong object's collection for callable filters over to-many relations (forward `GenericRelation`, `ManyToManyField`, or reverse FK). Such fields were mistaken for scalar foreign keys and cached by a key derived from a transient related manager's memory address; after garbage collection that address could be reused by another owner's manager, forging a cache hit and returning the wrong collection. To-many relations now fall back to the per-instance cache key.
+- [PR 197](https://github.com/salesforce/django-declarative-apis/pull/197) Fix: don't cache to-many relations by manager address in filter model cache.
 
 # [0.34.3]
 - [PR 187](https://github.com/salesforce/django-declarative-apis/pull/187) Replace unmaintained `oauth2` library with `oauthlib` in test infrastructure.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,7 +75,7 @@ author = "Salesforce"
 # built documents.
 
 # The full version, including alpha/beta/rc tags.
-release = "0.34.3"  # set by bumpversion
+release = "0.34.4"  # set by bumpversion
 
 # The short X.Y version.
 version = release.rsplit(".", 1)[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-declarative-apis"
-version = "0.34.3"  # set by bumpversion
+version = "0.34.4"  # set by bumpversion
 description = "Simple, readable, declarative APIs for Django"
 readme = "README.md"
 dependencies = [


### PR DESCRIPTION
## Summary
- Bump version to 0.34.4 via `bumpversion patch`
- Move the Unreleased changelog entry (PR #197 filter model cache fix) under a new `[0.34.4]` heading and add a fresh empty `[Unreleased]` section

## Test plan
- [ ] CI passes