### PR TITLE
chore(deps-dev): pin ruff lint rule set to historic default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased]
+- [PR 201](https://github.com/salesforce/django-declarative-apis/pull/201) Pin the ruff lint rule set to the historic default (E + F) so a ruff 0.16 upgrade stays behavior-neutral.
 
 # [0.34.4]
 - [PR 197](https://github.com/salesforce/django-declarative-apis/pull/197) Fix: don't cache to-many relations by manager address in filter model cache.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,10 @@ dev = [
 extend-exclude = [".heroku"]
 
 [tool.ruff.lint]
+# ruff 0.16 expanded its default rule set (~59 -> 413 rules). Pin the historic
+# default (E + F) explicitly so a ruff 0.16 upgrade stays behavior-neutral;
+# adopting the newly-default categories is a separate, deliberate decision.
+select = ["E4", "E7", "E9", "F"]
 extend-select = ["C901"]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Summary

Pin the ruff lint rule set to the historic default so a future ruff 0.16.x upgrade stays behavior-neutral.

ruff 0.16 expanded its default lint rule set (roughly 59 to 413 rules). This project's `[tool.ruff.lint]` sets no explicit `select`, so it inherits whatever ruff's default is. When ruff 0.16 is installed, `ruff check .` begins failing on newly-default rules that fire on existing code (for example `UP006`, `I001`).

This change sets `select = ["E4", "E7", "E9", "F"]` to pin the historic default rule categories (E + F), while preserving the existing `C901` complexity check via `extend-select`. Adopting the newly-default rule categories is left as a separate, deliberate decision.

## Verification

`ruff 0.16.0 check .` against this branch reports `All checks passed!` (exit 0). Without the pin, the same ruff 0.16.0 run reports 184 errors and would fail the build.

## Context

This unblocks the pending Dependabot dev-dependencies bump (#199), which widens the ruff ceiling to `<0.17.0` and would otherwise fail CI for exactly this reason.