### PR TITLE
chore: reformat README code blocks with ruff 0.16's Markdown formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 - [PR 201](https://github.com/salesforce/django-declarative-apis/pull/201) Pin the ruff lint rule set to the historic default (E + F) so a ruff 0.16 upgrade stays behavior-neutral.
+- [PR 203](https://github.com/salesforce/django-declarative-apis/pull/203) Reformat the README's Python code blocks with ruff 0.16's Markdown formatter so `ruff format --check` passes once ruff 0.16 is adopted.
 
 # [0.34.4]
 - [PR 197](https://github.com/salesforce/django-declarative-apis/pull/197) Fix: don't cache to-many relations by manager address in filter model cache.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Add app to INSTALLED\_APPS
 
 ``` python
 INSTALLED_APPS = [
-   'django_declarative_apis',
-   'myapp',
+    "django_declarative_apis",
+    "myapp",
 ]
 ```
 
@@ -40,8 +40,12 @@ Add required config
 -------------------
 
 ``` python
-DECLARATIVE_ENDPOINT_RESOURCE_ADAPTER = 'django_declarative_apis.adapters.EndpointResource'
-DECLARATIVE_ENDPOINT_AUTHENTICATION_HANDLERS = 'django_declarative_apis.authentication.oauthlib.oauth1.TwoLeggedOauth1'
+DECLARATIVE_ENDPOINT_RESOURCE_ADAPTER = (
+    "django_declarative_apis.adapters.EndpointResource"
+)
+DECLARATIVE_ENDPOINT_AUTHENTICATION_HANDLERS = (
+    "django_declarative_apis.authentication.oauthlib.oauth1.TwoLeggedOauth1"
+)
 ```
 
 myapp/urls.py
@@ -51,19 +55,19 @@ myapp/urls.py
 from django_declarative_apis import adapters
 import myapp.resources
 
+
 class NoAuth:
-   @staticmethod
-   def is_authenticated(request):
-      return True
+    @staticmethod
+    def is_authenticated(request):
+        return True
 
 
 urlpatterns = [
     url(
-        r'^ping$',
+        r"^ping$",
         adapters.resource_adapter(
-            get=myapp.resources.PingDefinition,
-            authentication=NoAuth
-        )
+            get=myapp.resources.PingDefinition, authentication=NoAuth
+        ),
     ),
 ]
 ```
@@ -76,7 +80,7 @@ from django.conf.urls import url, include
 import myapp.urls
 
 urlpatterns = [
-   url(r'^', include(myapp.urls)),
+    url(r"^", include(myapp.urls)),
 ]
 ```
 
@@ -93,7 +97,7 @@ class PingDefinition(machinery.BaseEndpointDefinition):
 
     @property
     def resource(self):
-        return {'ping': 'pong'}
+        return {"ping": "pong"}
 ```
 
 Optional: Implement Custom Event Hooks for Event Emission


### PR DESCRIPTION
## Summary

ruff 0.16 formats Python code blocks embedded in Markdown files — a new behavior ruff 0.15 does not have. As a result, once ruff 0.16 is installed, `ruff format --check` (the `formatcheck` target) fails on `README.md`'s example blocks (quote normalization, indentation, line-wrapping).

This applies ruff 0.16's formatting to the README's code blocks now, so the ruff dev-dependency ceiling can be raised to `<0.17.0` without breaking `make formatcheck`. Only `README.md` changes; no Python files are touched.

## Verification

- `ruff 0.16.0 format --check .` → `80 files already formatted` (0 to reformat) on this branch; fails with 1 file on `main`.
- ruff 0.15 (the currently pinned version) does not format Markdown, so this is a no-op under current CI and lands cleanly.

## Context

Follow-up to the ruff lint rule-set pin (#201). Together they make the pending dev-dependencies bump (#202, which raises the ruff ceiling to `<0.17.0`) pass CI.